### PR TITLE
Improve rendering of cli documentation in cli and in Read The Docs

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,0 +1,7 @@
+CLI
+===
+
+.. click:: traccuracy.cli:typer_click_object
+   :prog: traccuracy
+   :nested: full
+   

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "autoapi.extension",  # autobuild api docs
     "nbsphinx",  # add notebooks to docs
     "nbsphinx_link",  # add notebooks to docs
+    "sphinx_click",  # auto document cli
 ]
 
 napoleon_google_docstring = True
@@ -78,6 +79,7 @@ autoapi_options = [
     "show-module-summary",
     "imported-members",
 ]
+autoapi_ignore = ["*/cli.py"]
 
 # -- Nbsphinx extension ------------------------------------------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,3 +13,4 @@
    :caption: Traccuracy API:
 
    autoapi/traccuracy/index
+   cli

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ docs = [
     "m2r2",
     "sphinx-autoapi",
     "nbsphinx",
-    "nbsphinx-link"
+    "nbsphinx-link",
+    "sphinx-click"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ convention = "google"
 [tool.ruff.per-file-ignores]
 "tests/*.py" = ["D", "S"]
 "setup.py" = ["D"]
+"src/traccuracy/cli.py" = ["B008"]  # Ignore typer functions in function definitions
 
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]

--- a/src/traccuracy/cli.py
+++ b/src/traccuracy/cli.py
@@ -22,34 +22,29 @@ def load_all_ctc(
 
 @app.command()
 def run_ctc(
-    gt_dir: "str",
-    pred_dir: "str",
-    gt_track_path: "Optional[str]" = None,
-    pred_track_path: "Optional[str]" = None,
-    loader: "str" = "ctc",
-    out_path: "str" = "ctc_log.json",
+    gt_dir: "str" = typer.Argument(..., help="Path to GT tiffs", show_default=False),
+    pred_dir: "str" = typer.Argument(
+        ..., help="Path to prediction/RES tiffs", show_default=False
+    ),
+    gt_track_path: "Optional[str]" = typer.Option(
+        None, help="Path to ctc gt track file", show_default=False
+    ),
+    pred_track_path: "Optional[str]" = typer.Option(
+        None, help="Path to predicted track file", show_default=False
+    ),
+    loader: "str" = typer.Option("ctc", help="Loader to bring data into memory"),
+    out_path: "str" = typer.Option("ctc_log.json", help="Path to save results"),
 ):
-    """Run TRA and DET metric on gt and pred data using CTC matching.
+    """
+    Run TRA and DET metric on gt and pred data using CTC matching.
 
-    If gt_track_path and pred_track_path are not passed, we find *_track.txt
+    If --gt_track_path and --pred_track_path are not passed, we find *_track.txt
     files in the data directories. If more than one such file is present, or
     no such files are present, an error is raised.
 
-    Results will be dumped to out_path in JSON format.
+    Results will be dumped to --out_path in JSON format.
 
-    Args:
-        gt_dir (str): path to GT tiffs
-        pred_dir (str): path to prediction/RES tiffs
-        gt_track_path (Optional[str], optional): path to ctc gt track file.
-        Defaults to None.
-        pred_track_path (Optional[str], optional): path to predicted track file.
-        Defaults to None.
-        loader (str, optional): Loader to bring data into memory. Defaults to "ctc".
-        out_path (str, optional): Path to save results. Defaults to "ctc_log.json" in current
-        working directory.
-
-    Raises:
-        ValueError: if any loader besides ctc is passed.
+    Raises ValueError: if any --loader besides ctc is passed.
     """
     from traccuracy.matchers import CTCMatched
     from traccuracy.metrics import CTCMetrics
@@ -68,18 +63,36 @@ def run_ctc(
 
 @app.command()
 def run_aogm(
-    gt_dir: "str",
-    pred_dir: "str",
-    gt_track_path: "Optional[str]" = None,
-    pred_track_path: "Optional[str]" = None,
-    loader: "str" = "ctc",
-    out_path: "str" = "aogm_log.json",
-    vertex_ns_weight: "float" = 1,
-    vertex_fp_weight: "float" = 1,
-    vertex_fn_weight: "float" = 1,
-    edge_fp_weight: "float" = 1,
-    edge_fn_weight: "float" = 1,
-    edge_ws_weight: "float" = 1,
+    gt_dir: "str" = typer.Argument(..., help="Path to GT tiffs", show_default=False),
+    pred_dir: "str" = typer.Argument(
+        ..., help="Path to prediction/RES tiffs", show_default=False
+    ),
+    gt_track_path: "Optional[str]" = typer.Option(
+        None, help="Path to ctc gt track file", show_default=False
+    ),
+    pred_track_path: "Optional[str]" = typer.Option(
+        None, help="Path to predicted track file", show_default=False
+    ),
+    loader: "str" = typer.Option("ctc", help="Loader to bring data into memory"),
+    out_path: "str" = typer.Option("aogm_log.json", help="Path to save results"),
+    vertex_ns_weight: "float" = typer.Option(
+        1, help="Weight to assign to nonsplit vertex errors"
+    ),
+    vertex_fp_weight: "float" = typer.Option(
+        1, help="Weight to assign to false positive vertex errors"
+    ),
+    vertex_fn_weight: "float" = typer.Option(
+        1, help="Weight to assign to false negative vertex errors"
+    ),
+    edge_fp_weight: "float" = typer.Option(
+        1, help="Weight to assign to false positive edge errors"
+    ),
+    edge_fn_weight: "float" = typer.Option(
+        1, help="Weight to assign to false negative edge errors"
+    ),
+    edge_ws_weight: "float" = typer.Option(
+        1, help="Weight to assign to edges with incorrect semantics"
+    ),
 ):
     """Run general AOGM measure on gt and pred data using CTC matching.
 
@@ -91,31 +104,7 @@ def run_aogm(
 
     Results will be dumped to out_path in JSON format.
 
-    Args:
-        gt_dir (str): path to GT tiffs
-        pred_dir (str): path to prediction/RES tiffs
-        gt_track_path (Optional[str], optional): path to ctc gt track file.
-        Defaults to None.
-        pred_track_path (Optional[str], optional): path to predicted track file.
-        Defaults to None.
-        loader (str, optional): Loader to bring data into memory. Defaults to "ctc".
-        out_path (str, optional): Path to save results. Defaults to "ctc_log.json" in current
-        working directory.
-        vertex_ns_weight (float, optional): Weight to assign to nonsplit vertex errors.
-        Defaults to 1.
-        vertex_fp_weight (float, optional): Weight to assign to false positive vertex errors.
-        Defaults to 1.
-        vertex_fn_weight (float, optional): Weight to assign to false negative vertex errors.
-        Defaults to 1.
-        edge_fp_weight (float, optional): Weight to assign to false positive edge errors.
-        Defaults to 1.
-        edge_fn_weight (float, optional): Weight to assign to false negative edge errors.
-        Defaults to 1.
-        edge_ws_weight (float, optional): Weight to assign to edges with incorrect semantics.
-        Defaults to 1.
-
-    Raises:
-        ValueError: if any loader besides ctc is passed.
+    Raises ValueError: if any --loader besides ctc is passed.
     """
     from traccuracy.matchers import CTCMatched
     from traccuracy.metrics import AOGMMetrics
@@ -146,42 +135,40 @@ def run_aogm(
 
 @app.command()
 def run_divisions_on_iou(
-    gt_dir: "str",
-    pred_dir: "str",
-    gt_track_path: "Optional[str]" = None,
-    pred_track_path: "Optional[str]" = None,
-    loader: "str" = "ctc",
-    out_path: "str" = "div_log_iou.json",
-    match_threshold: "float" = 1,
-    frame_buffer: "int" = 0,
+    gt_dir: "str" = typer.Argument(..., help="Path to GT tiffs", show_default=False),
+    pred_dir: "str" = typer.Argument(
+        ..., help="Path to prediction/RES tiffs", show_default=False
+    ),
+    gt_track_path: "Optional[str]" = typer.Option(
+        None, help="Path to ctc gt track file", show_default=False
+    ),
+    pred_track_path: "Optional[str]" = typer.Option(
+        None, help="Path to predicted track file", show_default=False
+    ),
+    loader: "str" = typer.Option("ctc", help="Loader to bring data into memory"),
+    out_path: "str" = typer.Option("div_log_iou.json", help="Path to save results"),
+    match_threshold: "float" = typer.Option(
+        1,
+        help="Threshold above which the intersection over union of a gt and predicted"
+        " detection match. Default of 1 requires exact matching.",
+    ),
+    frame_buffer: "int" = typer.Option(
+        0,
+        help="Number of frames to use for division tolerance."
+        " Numbers greater than 0 will produce metrics for 0...n inclusive.",
+    ),
 ):
     """Run division metrics on gt and pred data using IOU matching.
 
-    If gt_track_path and pred_track_path are not passed, we find *_track.txt
+    If --gt_track_path and --pred_track_path are not passed, we find *_track.txt
     files in the data directories. If more than one such file is present, or
     no such files are present, an error is raised.
 
-    Optionally, a match_threshold and frame_buffer can be passed.
+    Optionally, a --match_threshold and --frame_buffer can be passed.
 
-    Results will be dumped to out_path in JSON format.
+    Results will be dumped to --out_path in JSON format.
 
-    Args:
-        gt_dir (str): path to GT tiffs
-        pred_dir (str): path to prediction/RES tiffs
-        gt_track_path (Optional[str], optional): path to ctc gt track file.
-        Defaults to None.
-        pred_track_path (Optional[str], optional): path to predicted track file.
-        Defaults to None.
-        loader (str, optional): Loader to bring data into memory. Defaults to "ctc".
-        out_path (str, optional): Path to save results. Defaults to "ctc_log.json" in current
-        working directory.
-        match_threshold (float, optional): Threshold above which the intersection over union
-        of a gt and predicted detection match. Defaults to 1 requiring exact matching.
-        frame_buffer (int, optional): Number of frames to use for division tolerance.
-        Defaults to 0. Numbers greater than 0 will produce metrics for 0...n inclusive.
-
-    Raises:
-        ValueError: if any loader besides ctc is passed.
+    Raises ValueError: if any --loader besides ctc is passed.
     """
     from traccuracy.matchers import IOUMatched
     from traccuracy.metrics import DivisionMetrics
@@ -212,39 +199,35 @@ def run_divisions_on_iou(
 
 @app.command()
 def run_divisions_on_ctc(
-    gt_dir: "str",
-    pred_dir: "str",
-    gt_track_path: "Optional[str]" = None,
-    pred_track_path: "Optional[str]" = None,
-    loader: "str" = "ctc",
-    out_path: "str" = "div_log_ctc.json",
-    frame_buffer: "int" = 0,
+    gt_dir: "str" = typer.Argument(..., help="Path to GT tiffs", show_default=False),
+    pred_dir: "str" = typer.Argument(
+        ..., help="Path to prediction/RES tiffs", show_default=False
+    ),
+    gt_track_path: "Optional[str]" = typer.Option(
+        None, help="Path to ctc gt track file", show_default=False
+    ),
+    pred_track_path: "Optional[str]" = typer.Option(
+        None, help="Path to predicted track file", show_default=False
+    ),
+    loader: "str" = typer.Option("ctc", help="Loader to bring data into memory"),
+    out_path: "str" = typer.Option("div_log_ctc.json", help="Path to save results"),
+    frame_buffer: "int" = typer.Option(
+        0,
+        help="Number of frames to use for division tolerance."
+        " Numbers greater than 0 will produce metrics for 0...n inclusive.",
+    ),
 ):
     """Run division metrics on gt and pred data using CTC matching.
 
-    If gt_track_path and pred_track_path are not passed, we find *_track.txt
+    If --gt_track_path and --pred_track_path are not passed, we find *_track.txt
     files in the data directories. If more than one such file is present, or
     no such files are present, an error is raised.
 
-    Optionally, a frame_buffer can be passed.
+    Optionally, a --frame_buffer can be passed.
 
-    Results will be dumped to out_path in JSON format.
+    Results will be dumped to --out_path in JSON format.
 
-    Args:
-        gt_dir (str): path to GT tiffs
-        pred_dir (str): path to prediction/RES tiffs
-        gt_track_path (Optional[str], optional): path to ctc gt track file.
-        Defaults to None.
-        pred_track_path (Optional[str], optional): path to predicted track file.
-        Defaults to None.
-        loader (str, optional): Loader to bring data into memory. Defaults to "ctc".
-        out_path (str, optional): Path to save results. Defaults to "ctc_log.json" in current
-        working directory.
-        frame_buffer (int, optional): Number of frames to use for division tolerance.
-        Defaults to 0. Numbers greater than 0 will produce metrics for 0...n inclusive.
-
-    Raises:
-        ValueError: if any loader besides ctc is passed.
+    Raises ValueError: if any --loader besides ctc is passed.
     """
     from traccuracy.matchers import CTCMatched
     from traccuracy.metrics import DivisionMetrics

--- a/src/traccuracy/cli.py
+++ b/src/traccuracy/cli.py
@@ -255,5 +255,8 @@ def run_divisions_on_ctc(
     print(res_str)
 
 
+typer_click_object = typer.main.get_command(app)
+
+
 def main():
     app()


### PR DESCRIPTION
I cleaned up the appearance of the `--help` output by moving content from the docstring into `typer.Argument` and `typer.Optional`.
<img width="1410" alt="Screen Shot 2023-03-17 at 4 17 08 PM" src="https://user-images.githubusercontent.com/20373588/226068297-c084aec6-93a6-40be-b853-41bb7178c14d.png">

Additionally, the CLI is now autodocumented by sphinx, see example [here](https://traccuracy.readthedocs.io/en/cli-docs/cli.html).