### PR TITLE
Add report of matcher coverage

### DIFF
--- a/src/traccuracy/matchers/_matched.py
+++ b/src/traccuracy/matchers/_matched.py
@@ -20,6 +20,14 @@ class Matched(ABC):
 
         self.mapping = self.compute_mapping()
 
+        # Report matching performance
+        total_gt = len(self.gt_data.tracking_graph.nodes())
+        matched_gt = len({m[0] for m in self.mapping})
+        total_pred = len(self.pred_data.tracking_graph.nodes())
+        matched_pred = len({m[1] for m in self.mapping})
+        print(f"Matched {matched_gt} out of {total_gt} ground truth nodes.")
+        print(f"Matched {matched_pred} out of {total_pred} predicted nodes.")
+
     @abstractmethod
     def compute_mapping(self):
         """Computes a mapping of nodes in gt to nodes in pred


### PR DESCRIPTION
This addition to the base `Matched` class prints the fraction of matched GT and predicted nodes. Let me know if you think we should switch to a logger instead of printing, but I figured printing would makes sense since we print the results of the metrics later on.