### PR TITLE
Use appropriate label key for `gt` and `pred` graphs in `ctc` matching

### DIFF
--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -45,8 +45,8 @@ class CTCMatched(Matched):
             )
         gt = self.gt_data
         pred = self.pred_data
-        label_key = self.gt_data.tracking_graph.label_key
-
+        gt_label_key = self.gt_data.tracking_graph.label_key
+        pred_label_key = self.pred_data.tracking_graph.label_key
         G_gt, mask_gt = gt.tracking_graph, gt.segmentation
         G_pred, mask_pred = pred.tracking_graph, pred.segmentation
 
@@ -70,13 +70,13 @@ class CTCMatched(Matched):
             gt_labels = dict(
                 filter(
                     lambda item: item[0] in gt_frame_nodes,
-                    nx.get_node_attributes(G_gt.graph, label_key).items(),
+                    nx.get_node_attributes(G_gt.graph, gt_label_key).items(),
                 )
             )
             pred_labels = dict(
                 filter(
                     lambda item: item[0] in pred_frame_nodes,
-                    nx.get_node_attributes(G_pred.graph, label_key).items(),
+                    nx.get_node_attributes(G_pred.graph, pred_label_key).items(),
                 )
             )
 


### PR DESCRIPTION
CTC matcher previously assumed `label_key` would be the same for `gt` and `pred` graphs. Obviously this may not be the case, so updating this.