### PR TITLE
Remove detection matrix computation

### DIFF
--- a/examples/ctc.ipynb
+++ b/examples/ctc.ipynb
@@ -89,23 +89,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 374.71it/s]\n",
-      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 824.06it/s]\n"
+      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 122.31it/s]\n",
+      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 158.07it/s]\n"
      ]
     }
    ],
    "source": [
     "\n",
     "gt_data = load_ctc_data(\n",
-    "    'downloads/Fluo-N2DL-HeLa/01_GT/TRA',\n",
-    "    'downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt'\n",
+    "    '/home/draga/PhD/data/cell_tracking_challenge/ST_Segmentations/Fluo-N2DL-HeLa/01_GT/TRA',\n",
+    "    '/home/draga/PhD/data/cell_tracking_challenge/ST_Segmentations/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt'\n",
     ")\n",
     "pred_data = load_ctc_data(\n",
     "    'sample-data/Fluo-N2DL-HeLa/01_RES', \n",
@@ -123,55 +123,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Matching frames: 100%|██████████| 92/92 [00:13<00:00,  6.65it/s]\n",
-      "Evaluating nodes: 100%|██████████| 92/92 [00:00<00:00, 10573.68it/s]\n",
-      "Evaluating edges: 100%|██████████| 8535/8535 [00:06<00:00, 1359.15it/s]\n"
+      "Matching frames: 100%|██████████| 92/92 [00:20<00:00,  4.47it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{   'CTCMetrics': {   'AOGM': 631.5,\n",
-      "                      'DET': 0.9954855886097927,\n",
-      "                      'TRA': 0.9936361895740329,\n",
-      "                      'fn_edges': 87,\n",
-      "                      'fn_nodes': 39,\n",
-      "                      'fp_edges': 60,\n",
-      "                      'fp_nodes': 0,\n",
-      "                      'ns_nodes': 0,\n",
-      "                      'ws_edges': 51},\n",
-      "    'DivisionMetrics': {   'Frame Buffer 0': {   'Division F1': 0.76,\n",
-      "                                                 'Division Precision': 0.7169811320754716,\n",
-      "                                                 'Division Recall': 0.8085106382978723,\n",
-      "                                                 'False Negative Divisions': 18,\n",
-      "                                                 'False Positive Divisions': 30,\n",
-      "                                                 'Mitotic Branching Correctness': 0.6129032258064516,\n",
-      "                                                 'Total GT Divisions': 94,\n",
-      "                                                 'True Positive Divisions': 76},\n",
-      "                           'Frame Buffer 1': {   'Division F1': 0.76,\n",
-      "                                                 'Division Precision': 0.7169811320754716,\n",
-      "                                                 'Division Recall': 0.8085106382978723,\n",
-      "                                                 'False Negative Divisions': 18,\n",
-      "                                                 'False Positive Divisions': 30,\n",
-      "                                                 'Mitotic Branching Correctness': 0.6129032258064516,\n",
-      "                                                 'Total GT Divisions': 94,\n",
-      "                                                 'True Positive Divisions': 76},\n",
-      "                           'Frame Buffer 2': {   'Division F1': 0.76,\n",
-      "                                                 'Division Precision': 0.7169811320754716,\n",
-      "                                                 'Division Recall': 0.8085106382978723,\n",
-      "                                                 'False Negative Divisions': 18,\n",
-      "                                                 'False Positive Divisions': 30,\n",
-      "                                                 'Mitotic Branching Correctness': 0.6129032258064516,\n",
-      "                                                 'Total GT Divisions': 94,\n",
-      "                                                 'True Positive Divisions': 76}}}\n"
+      "Matched 8600 out of 8639 ground truth nodes.\n",
+      "Matched 8600 out of 8600 predicted nodes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Evaluating nodes: 100%|██████████| 92/92 [00:00<00:00, 3636.53it/s]\n",
+      "Evaluating FP edges:  67%|██████▋   | 5683/8535 [00:12<00:06, 449.83it/s]\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[4], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m ctc_results \u001b[39m=\u001b[39m run_metrics(\n\u001b[1;32m      2\u001b[0m     gt_data\u001b[39m=\u001b[39;49mgt_data, \n\u001b[1;32m      3\u001b[0m     pred_data\u001b[39m=\u001b[39;49mpred_data, \n\u001b[1;32m      4\u001b[0m     matcher\u001b[39m=\u001b[39;49mCTCMatched, \n\u001b[1;32m      5\u001b[0m     metrics\u001b[39m=\u001b[39;49m[CTCMetrics, DivisionMetrics],\n\u001b[1;32m      6\u001b[0m     metrics_kwargs\u001b[39m=\u001b[39;49m\u001b[39mdict\u001b[39;49m(\n\u001b[1;32m      7\u001b[0m         frame_buffer\u001b[39m=\u001b[39;49m(\u001b[39m0\u001b[39;49m,\u001b[39m1\u001b[39;49m,\u001b[39m2\u001b[39;49m)\n\u001b[1;32m      8\u001b[0m     )\n\u001b[1;32m      9\u001b[0m )\n\u001b[1;32m     10\u001b[0m pp\u001b[39m.\u001b[39mpprint(ctc_results)\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/_run_metrics.py:53\u001b[0m, in \u001b[0;36mrun_metrics\u001b[0;34m(gt_data, pred_data, matcher, metrics, matcher_kwargs, metrics_kwargs)\u001b[0m\n\u001b[1;32m     51\u001b[0m \u001b[39mfor\u001b[39;00m _metric \u001b[39min\u001b[39;00m metrics:\n\u001b[1;32m     52\u001b[0m     relevant_kwargs \u001b[39m=\u001b[39m metric_kwarg_dict[_metric]\n\u001b[0;32m---> 53\u001b[0m     result \u001b[39m=\u001b[39m _metric(matched, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mrelevant_kwargs)\n\u001b[1;32m     54\u001b[0m     results[_metric\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m] \u001b[39m=\u001b[39m result\u001b[39m.\u001b[39mresults\n\u001b[1;32m     55\u001b[0m \u001b[39mreturn\u001b[39;00m results\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_ctc.py:83\u001b[0m, in \u001b[0;36mCTCMetrics.__init__\u001b[0;34m(self, matched_data)\u001b[0m\n\u001b[1;32m     81\u001b[0m edge_weight_fn \u001b[39m=\u001b[39m \u001b[39m1.5\u001b[39m\n\u001b[1;32m     82\u001b[0m edge_weight_ws \u001b[39m=\u001b[39m \u001b[39m1\u001b[39m\n\u001b[0;32m---> 83\u001b[0m \u001b[39msuper\u001b[39;49m()\u001b[39m.\u001b[39;49m\u001b[39m__init__\u001b[39;49m(\n\u001b[1;32m     84\u001b[0m     matched_data,\n\u001b[1;32m     85\u001b[0m     vertex_ns_weight\u001b[39m=\u001b[39;49mvertex_weight_ns,\n\u001b[1;32m     86\u001b[0m     vertex_fp_weight\u001b[39m=\u001b[39;49mvertex_weight_fp,\n\u001b[1;32m     87\u001b[0m     vertex_fn_weight\u001b[39m=\u001b[39;49mvertex_weight_fn,\n\u001b[1;32m     88\u001b[0m     edge_fp_weight\u001b[39m=\u001b[39;49medge_weight_fp,\n\u001b[1;32m     89\u001b[0m     edge_fn_weight\u001b[39m=\u001b[39;49medge_weight_fn,\n\u001b[1;32m     90\u001b[0m     edge_ws_weight\u001b[39m=\u001b[39;49medge_weight_ws,\n\u001b[1;32m     91\u001b[0m )\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_ctc.py:34\u001b[0m, in \u001b[0;36mAOGMMetrics.__init__\u001b[0;34m(self, matched_data, vertex_ns_weight, vertex_fp_weight, vertex_fn_weight, edge_fp_weight, edge_fn_weight, edge_ws_weight)\u001b[0m\n\u001b[1;32m     24\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mv_weights \u001b[39m=\u001b[39m {\n\u001b[1;32m     25\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mns\u001b[39m\u001b[39m\"\u001b[39m: vertex_ns_weight,\n\u001b[1;32m     26\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfp\u001b[39m\u001b[39m\"\u001b[39m: vertex_fp_weight,\n\u001b[1;32m     27\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m\"\u001b[39m: vertex_fn_weight,\n\u001b[1;32m     28\u001b[0m }\n\u001b[1;32m     29\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39me_weights \u001b[39m=\u001b[39m {\n\u001b[1;32m     30\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfp\u001b[39m\u001b[39m\"\u001b[39m: edge_fp_weight,\n\u001b[1;32m     31\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m\"\u001b[39m: edge_fn_weight,\n\u001b[1;32m     32\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mws\u001b[39m\u001b[39m\"\u001b[39m: edge_ws_weight,\n\u001b[1;32m     33\u001b[0m }\n\u001b[0;32m---> 34\u001b[0m \u001b[39msuper\u001b[39;49m()\u001b[39m.\u001b[39;49m\u001b[39m__init__\u001b[39;49m(matched_data)\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_base.py:26\u001b[0m, in \u001b[0;36mMetric.__init__\u001b[0;34m(self, matched_data)\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[39m\u001b[39m\u001b[39m\"\"\"Add Matched class which takes TrackingData objects for gt and pred,and computes matching\u001b[39;00m\n\u001b[1;32m     16\u001b[0m \n\u001b[1;32m     17\u001b[0m \u001b[39mEach current matching method will be a subclass of Matched e.g. CTCMatched or IOUMatched.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     23\u001b[0m \u001b[39m    matched_data (Matched): Matched object for set of GT and Pred data\u001b[39;00m\n\u001b[1;32m     24\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m     25\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata \u001b[39m=\u001b[39m matched_data\n\u001b[0;32m---> 26\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mresults \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mcompute()\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_ctc.py:105\u001b[0m, in \u001b[0;36mCTCMetrics.compute\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     99\u001b[0m \u001b[39mif\u001b[39;00m aogm_0 \u001b[39m==\u001b[39m \u001b[39m0\u001b[39m:\n\u001b[1;32m    100\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mRuntimeError\u001b[39;00m(\n\u001b[1;32m    101\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mAOGM0 is 0 - cannot compute TRA from GT graph with \u001b[39m\u001b[39m{\u001b[39;00mn_nodes\u001b[39m}\u001b[39;00m\u001b[39m nodes and\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    102\u001b[0m         \u001b[39m+\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m \u001b[39m\u001b[39m{\u001b[39;00mn_edges\u001b[39m}\u001b[39;00m\u001b[39m edges with \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mv_weights[\u001b[39m'\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m}\u001b[39;00m\u001b[39m vertex FN weight and\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    103\u001b[0m         \u001b[39m+\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39me_weights[\u001b[39m'\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m}\u001b[39;00m\u001b[39m edge FN weight\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    104\u001b[0m     )\n\u001b[0;32m--> 105\u001b[0m errors \u001b[39m=\u001b[39m \u001b[39msuper\u001b[39;49m()\u001b[39m.\u001b[39;49mcompute()\n\u001b[1;32m    106\u001b[0m aogm \u001b[39m=\u001b[39m errors[\u001b[39m\"\u001b[39m\u001b[39mAOGM\u001b[39m\u001b[39m\"\u001b[39m]\n\u001b[1;32m    107\u001b[0m tra \u001b[39m=\u001b[39m \u001b[39m1\u001b[39m \u001b[39m-\u001b[39m \u001b[39mmin\u001b[39m(aogm, aogm_0) \u001b[39m/\u001b[39m aogm_0\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_ctc.py:42\u001b[0m, in \u001b[0;36mAOGMMetrics.compute\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     39\u001b[0m mapping \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata\u001b[39m.\u001b[39mmapping\n\u001b[1;32m     40\u001b[0m matrices \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata\u001b[39m.\u001b[39m_det_matrices\n\u001b[0;32m---> 42\u001b[0m track_events \u001b[39m=\u001b[39m evaluate_ctc_events(gt_graph, pred_graph, mapping, matrices)\n\u001b[1;32m     43\u001b[0m vertex_error_counts \u001b[39m=\u001b[39m {\n\u001b[1;32m     44\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mns\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mnonsplit_vertices_count,\n\u001b[1;32m     45\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfp\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mfp_node_count,\n\u001b[1;32m     46\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mfn_node_count,\n\u001b[1;32m     47\u001b[0m }\n\u001b[1;32m     48\u001b[0m edge_error_counts \u001b[39m=\u001b[39m {\n\u001b[1;32m     49\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mws\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mincorrect_semantics_count,\n\u001b[1;32m     50\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfp\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mfp_edge_count,\n\u001b[1;32m     51\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mfn_edge_count,\n\u001b[1;32m     52\u001b[0m }\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/track_errors/_ctc.py:21\u001b[0m, in \u001b[0;36mevaluate_ctc_events\u001b[0;34m(G_gt, G_pred, mapper, det_matrices)\u001b[0m\n\u001b[1;32m     19\u001b[0m pred_nx_graph \u001b[39m=\u001b[39m G_pred\u001b[39m.\u001b[39mgraph\n\u001b[1;32m     20\u001b[0m node_errors \u001b[39m=\u001b[39m get_vertex_errors(gt_nx_graph, pred_nx_graph, det_matrices)\n\u001b[0;32m---> 21\u001b[0m edge_errors \u001b[39m=\u001b[39m get_edge_errors(gt_nx_graph, pred_nx_graph, mapper)\n\u001b[1;32m     23\u001b[0m track_events \u001b[39m=\u001b[39m TrackEvents(\n\u001b[1;32m     24\u001b[0m     fp_nodes\u001b[39m=\u001b[39mnode_errors[\u001b[39m\"\u001b[39m\u001b[39mfp_nodes\u001b[39m\u001b[39m\"\u001b[39m],\n\u001b[1;32m     25\u001b[0m     fn_nodes\u001b[39m=\u001b[39mnode_errors[\u001b[39m\"\u001b[39m\u001b[39mfn_nodes\u001b[39m\u001b[39m\"\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     29\u001b[0m     incorrect_semantics\u001b[39m=\u001b[39medge_errors[\u001b[39m\"\u001b[39m\u001b[39mws_edges\u001b[39m\u001b[39m\"\u001b[39m],\n\u001b[1;32m     30\u001b[0m )\n\u001b[1;32m     31\u001b[0m \u001b[39mreturn\u001b[39;00m track_events\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/track_errors/_ctc.py:131\u001b[0m, in \u001b[0;36mget_edge_errors\u001b[0;34m(gt_graph, comp_graph, node_mapping)\u001b[0m\n\u001b[1;32m    129\u001b[0m source, target \u001b[39m=\u001b[39m edge[\u001b[39m0\u001b[39m], edge[\u001b[39m1\u001b[39m]\n\u001b[1;32m    130\u001b[0m source_gt_id \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(\u001b[39mfilter\u001b[39m(\u001b[39mlambda\u001b[39;00m mp: mp[\u001b[39m1\u001b[39m] \u001b[39m==\u001b[39m source, node_mapping))[\u001b[39m0\u001b[39m][\u001b[39m0\u001b[39m]\n\u001b[0;32m--> 131\u001b[0m target_gt_id \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39;49m(\u001b[39mfilter\u001b[39;49m(\u001b[39mlambda\u001b[39;49;00m mp: mp[\u001b[39m1\u001b[39;49m] \u001b[39m==\u001b[39;49m target, node_mapping))[\u001b[39m0\u001b[39m][\u001b[39m0\u001b[39m]\n\u001b[1;32m    132\u001b[0m expected_gt_edge \u001b[39m=\u001b[39m (source_gt_id, target_gt_id)\n\u001b[1;32m    133\u001b[0m \u001b[39mif\u001b[39;00m expected_gt_edge \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m gt_graph\u001b[39m.\u001b[39medges:\n",
+      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/track_errors/_ctc.py:131\u001b[0m, in \u001b[0;36mget_edge_errors.<locals>.<lambda>\u001b[0;34m(mp)\u001b[0m\n\u001b[1;32m    129\u001b[0m source, target \u001b[39m=\u001b[39m edge[\u001b[39m0\u001b[39m], edge[\u001b[39m1\u001b[39m]\n\u001b[1;32m    130\u001b[0m source_gt_id \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(\u001b[39mfilter\u001b[39m(\u001b[39mlambda\u001b[39;00m mp: mp[\u001b[39m1\u001b[39m] \u001b[39m==\u001b[39m source, node_mapping))[\u001b[39m0\u001b[39m][\u001b[39m0\u001b[39m]\n\u001b[0;32m--> 131\u001b[0m target_gt_id \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(\u001b[39mfilter\u001b[39m(\u001b[39mlambda\u001b[39;00m mp: mp[\u001b[39m1\u001b[39m] \u001b[39m==\u001b[39m target, node_mapping))[\u001b[39m0\u001b[39m][\u001b[39m0\u001b[39m]\n\u001b[1;32m    132\u001b[0m expected_gt_edge \u001b[39m=\u001b[39m (source_gt_id, target_gt_id)\n\u001b[1;32m    133\u001b[0m \u001b[39mif\u001b[39;00m expected_gt_edge \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m gt_graph\u001b[39m.\u001b[39medges:\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
      ]
     }
    ],

--- a/examples/ctc.ipynb
+++ b/examples/ctc.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,24 +49,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading Fluo-N2DL-HeLa data from the CTC website\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Fluo-N2DL-HeLa.zip: 191MB [00:18, 10.2MB/s]                              \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Add a utility to make a progress bar when downloading the file\n",
     "class DownloadProgressBar(tqdm):\n",
@@ -193,40 +178,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{   'DivisionMetrics': {   'Frame Buffer 0': {   'Division F1': 0,\n",
-      "                                                 'Division Precision': 0.0,\n",
-      "                                                 'Division Recall': 0.0,\n",
-      "                                                 'False Negative Divisions': 94,\n",
-      "                                                 'False Positive Divisions': 93,\n",
-      "                                                 'Mitotic Branching Correctness': 0.0,\n",
-      "                                                 'Total GT Divisions': 94,\n",
-      "                                                 'True Positive Divisions': 0},\n",
-      "                           'Frame Buffer 1': {   'Division F1': 0.44837758112094395,\n",
-      "                                                 'Division Precision': 0.44970414201183434,\n",
-      "                                                 'Division Recall': 0.4470588235294118,\n",
-      "                                                 'False Negative Divisions': 94,\n",
-      "                                                 'False Positive Divisions': 93,\n",
-      "                                                 'Mitotic Branching Correctness': 0.2889733840304182,\n",
-      "                                                 'Total GT Divisions': 94,\n",
-      "                                                 'True Positive Divisions': 76},\n",
-      "                           'Frame Buffer 2': {   'Division F1': 0.44837758112094395,\n",
-      "                                                 'Division Precision': 0.44970414201183434,\n",
-      "                                                 'Division Recall': 0.4470588235294118,\n",
-      "                                                 'False Negative Divisions': 94,\n",
-      "                                                 'False Positive Divisions': 93,\n",
-      "                                                 'Mitotic Branching Correctness': 0.2889733840304182,\n",
-      "                                                 'Total GT Divisions': 94,\n",
-      "                                                 'True Positive Divisions': 76}}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "iou_results = run_metrics(\n",
     "    gt_data=gt_data, \n",
@@ -260,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.9.16"
   },
   "orig_nbformat": 4
  },

--- a/examples/ctc.ipynb
+++ b/examples/ctc.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,9 +49,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading Fluo-N2DL-HeLa data from the CTC website\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Fluo-N2DL-HeLa.zip: 191MB [00:18, 10.2MB/s]                              \n"
+     ]
+    }
+   ],
    "source": [
     "# Add a utility to make a progress bar when downloading the file\n",
     "class DownloadProgressBar(tqdm):\n",
@@ -74,23 +89,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 122.31it/s]\n",
-      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 158.07it/s]\n"
+      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 374.71it/s]\n",
+      "Loading TIFFs: 100%|██████████| 92/92 [00:00<00:00, 824.06it/s]\n"
      ]
     }
    ],
    "source": [
     "\n",
     "gt_data = load_ctc_data(\n",
-    "    '/home/draga/PhD/data/cell_tracking_challenge/ST_Segmentations/Fluo-N2DL-HeLa/01_GT/TRA',\n",
-    "    '/home/draga/PhD/data/cell_tracking_challenge/ST_Segmentations/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt'\n",
+    "    'downloads/Fluo-N2DL-HeLa/01_GT/TRA',\n",
+    "    'downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt'\n",
     ")\n",
     "pred_data = load_ctc_data(\n",
     "    'sample-data/Fluo-N2DL-HeLa/01_RES', \n",
@@ -108,50 +123,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Matching frames: 100%|██████████| 92/92 [00:20<00:00,  4.47it/s]\n"
+      "Matching frames: 100%|██████████| 92/92 [00:13<00:00,  6.65it/s]\n",
+      "Evaluating nodes: 100%|██████████| 92/92 [00:00<00:00, 10573.68it/s]\n",
+      "Evaluating edges: 100%|██████████| 8535/8535 [00:06<00:00, 1359.15it/s]\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Matched 8600 out of 8639 ground truth nodes.\n",
-      "Matched 8600 out of 8600 predicted nodes.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Evaluating nodes: 100%|██████████| 92/92 [00:00<00:00, 3636.53it/s]\n",
-      "Evaluating FP edges:  67%|██████▋   | 5683/8535 [00:12<00:06, 449.83it/s]\n"
-     ]
-    },
-    {
-     "ename": "KeyboardInterrupt",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[4], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m ctc_results \u001b[39m=\u001b[39m run_metrics(\n\u001b[1;32m      2\u001b[0m     gt_data\u001b[39m=\u001b[39;49mgt_data, \n\u001b[1;32m      3\u001b[0m     pred_data\u001b[39m=\u001b[39;49mpred_data, \n\u001b[1;32m      4\u001b[0m     matcher\u001b[39m=\u001b[39;49mCTCMatched, \n\u001b[1;32m      5\u001b[0m     metrics\u001b[39m=\u001b[39;49m[CTCMetrics, DivisionMetrics],\n\u001b[1;32m      6\u001b[0m     metrics_kwargs\u001b[39m=\u001b[39;49m\u001b[39mdict\u001b[39;49m(\n\u001b[1;32m      7\u001b[0m         frame_buffer\u001b[39m=\u001b[39;49m(\u001b[39m0\u001b[39;49m,\u001b[39m1\u001b[39;49m,\u001b[39m2\u001b[39;49m)\n\u001b[1;32m      8\u001b[0m     )\n\u001b[1;32m      9\u001b[0m )\n\u001b[1;32m     10\u001b[0m pp\u001b[39m.\u001b[39mpprint(ctc_results)\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/_run_metrics.py:53\u001b[0m, in \u001b[0;36mrun_metrics\u001b[0;34m(gt_data, pred_data, matcher, metrics, matcher_kwargs, metrics_kwargs)\u001b[0m\n\u001b[1;32m     51\u001b[0m \u001b[39mfor\u001b[39;00m _metric \u001b[39min\u001b[39;00m metrics:\n\u001b[1;32m     52\u001b[0m     relevant_kwargs \u001b[39m=\u001b[39m metric_kwarg_dict[_metric]\n\u001b[0;32m---> 53\u001b[0m     result \u001b[39m=\u001b[39m _metric(matched, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mrelevant_kwargs)\n\u001b[1;32m     54\u001b[0m     results[_metric\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m] \u001b[39m=\u001b[39m result\u001b[39m.\u001b[39mresults\n\u001b[1;32m     55\u001b[0m \u001b[39mreturn\u001b[39;00m results\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_ctc.py:83\u001b[0m, in \u001b[0;36mCTCMetrics.__init__\u001b[0;34m(self, matched_data)\u001b[0m\n\u001b[1;32m     81\u001b[0m edge_weight_fn \u001b[39m=\u001b[39m \u001b[39m1.5\u001b[39m\n\u001b[1;32m     82\u001b[0m edge_weight_ws \u001b[39m=\u001b[39m \u001b[39m1\u001b[39m\n\u001b[0;32m---> 83\u001b[0m \u001b[39msuper\u001b[39;49m()\u001b[39m.\u001b[39;49m\u001b[39m__init__\u001b[39;49m(\n\u001b[1;32m     84\u001b[0m     matched_data,\n\u001b[1;32m     85\u001b[0m     vertex_ns_weight\u001b[39m=\u001b[39;49mvertex_weight_ns,\n\u001b[1;32m     86\u001b[0m     vertex_fp_weight\u001b[39m=\u001b[39;49mvertex_weight_fp,\n\u001b[1;32m     87\u001b[0m     vertex_fn_weight\u001b[39m=\u001b[39;49mvertex_weight_fn,\n\u001b[1;32m     88\u001b[0m     edge_fp_weight\u001b[39m=\u001b[39;49medge_weight_fp,\n\u001b[1;32m     89\u001b[0m     edge_fn_weight\u001b[39m=\u001b[39;49medge_weight_fn,\n\u001b[1;32m     90\u001b[0m     edge_ws_weight\u001b[39m=\u001b[39;49medge_weight_ws,\n\u001b[1;32m     91\u001b[0m )\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_ctc.py:34\u001b[0m, in \u001b[0;36mAOGMMetrics.__init__\u001b[0;34m(self, matched_data, vertex_ns_weight, vertex_fp_weight, vertex_fn_weight, edge_fp_weight, edge_fn_weight, edge_ws_weight)\u001b[0m\n\u001b[1;32m     24\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mv_weights \u001b[39m=\u001b[39m {\n\u001b[1;32m     25\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mns\u001b[39m\u001b[39m\"\u001b[39m: vertex_ns_weight,\n\u001b[1;32m     26\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfp\u001b[39m\u001b[39m\"\u001b[39m: vertex_fp_weight,\n\u001b[1;32m     27\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m\"\u001b[39m: vertex_fn_weight,\n\u001b[1;32m     28\u001b[0m }\n\u001b[1;32m     29\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39me_weights \u001b[39m=\u001b[39m {\n\u001b[1;32m     30\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfp\u001b[39m\u001b[39m\"\u001b[39m: edge_fp_weight,\n\u001b[1;32m     31\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m\"\u001b[39m: edge_fn_weight,\n\u001b[1;32m     32\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mws\u001b[39m\u001b[39m\"\u001b[39m: edge_ws_weight,\n\u001b[1;32m     33\u001b[0m }\n\u001b[0;32m---> 34\u001b[0m \u001b[39msuper\u001b[39;49m()\u001b[39m.\u001b[39;49m\u001b[39m__init__\u001b[39;49m(matched_data)\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_base.py:26\u001b[0m, in \u001b[0;36mMetric.__init__\u001b[0;34m(self, matched_data)\u001b[0m\n\u001b[1;32m     15\u001b[0m \u001b[39m\u001b[39m\u001b[39m\"\"\"Add Matched class which takes TrackingData objects for gt and pred,and computes matching\u001b[39;00m\n\u001b[1;32m     16\u001b[0m \n\u001b[1;32m     17\u001b[0m \u001b[39mEach current matching method will be a subclass of Matched e.g. CTCMatched or IOUMatched.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     23\u001b[0m \u001b[39m    matched_data (Matched): Matched object for set of GT and Pred data\u001b[39;00m\n\u001b[1;32m     24\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m     25\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata \u001b[39m=\u001b[39m matched_data\n\u001b[0;32m---> 26\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mresults \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mcompute()\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_ctc.py:105\u001b[0m, in \u001b[0;36mCTCMetrics.compute\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     99\u001b[0m \u001b[39mif\u001b[39;00m aogm_0 \u001b[39m==\u001b[39m \u001b[39m0\u001b[39m:\n\u001b[1;32m    100\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mRuntimeError\u001b[39;00m(\n\u001b[1;32m    101\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mAOGM0 is 0 - cannot compute TRA from GT graph with \u001b[39m\u001b[39m{\u001b[39;00mn_nodes\u001b[39m}\u001b[39;00m\u001b[39m nodes and\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    102\u001b[0m         \u001b[39m+\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m \u001b[39m\u001b[39m{\u001b[39;00mn_edges\u001b[39m}\u001b[39;00m\u001b[39m edges with \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39mv_weights[\u001b[39m'\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m}\u001b[39;00m\u001b[39m vertex FN weight and\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    103\u001b[0m         \u001b[39m+\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39me_weights[\u001b[39m'\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m}\u001b[39;00m\u001b[39m edge FN weight\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    104\u001b[0m     )\n\u001b[0;32m--> 105\u001b[0m errors \u001b[39m=\u001b[39m \u001b[39msuper\u001b[39;49m()\u001b[39m.\u001b[39;49mcompute()\n\u001b[1;32m    106\u001b[0m aogm \u001b[39m=\u001b[39m errors[\u001b[39m\"\u001b[39m\u001b[39mAOGM\u001b[39m\u001b[39m\"\u001b[39m]\n\u001b[1;32m    107\u001b[0m tra \u001b[39m=\u001b[39m \u001b[39m1\u001b[39m \u001b[39m-\u001b[39m \u001b[39mmin\u001b[39m(aogm, aogm_0) \u001b[39m/\u001b[39m aogm_0\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/metrics/_ctc.py:42\u001b[0m, in \u001b[0;36mAOGMMetrics.compute\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     39\u001b[0m mapping \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata\u001b[39m.\u001b[39mmapping\n\u001b[1;32m     40\u001b[0m matrices \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mdata\u001b[39m.\u001b[39m_det_matrices\n\u001b[0;32m---> 42\u001b[0m track_events \u001b[39m=\u001b[39m evaluate_ctc_events(gt_graph, pred_graph, mapping, matrices)\n\u001b[1;32m     43\u001b[0m vertex_error_counts \u001b[39m=\u001b[39m {\n\u001b[1;32m     44\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mns\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mnonsplit_vertices_count,\n\u001b[1;32m     45\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfp\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mfp_node_count,\n\u001b[1;32m     46\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mfn_node_count,\n\u001b[1;32m     47\u001b[0m }\n\u001b[1;32m     48\u001b[0m edge_error_counts \u001b[39m=\u001b[39m {\n\u001b[1;32m     49\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mws\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mincorrect_semantics_count,\n\u001b[1;32m     50\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfp\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mfp_edge_count,\n\u001b[1;32m     51\u001b[0m     \u001b[39m\"\u001b[39m\u001b[39mfn\u001b[39m\u001b[39m\"\u001b[39m: track_events\u001b[39m.\u001b[39mfn_edge_count,\n\u001b[1;32m     52\u001b[0m }\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/track_errors/_ctc.py:21\u001b[0m, in \u001b[0;36mevaluate_ctc_events\u001b[0;34m(G_gt, G_pred, mapper, det_matrices)\u001b[0m\n\u001b[1;32m     19\u001b[0m pred_nx_graph \u001b[39m=\u001b[39m G_pred\u001b[39m.\u001b[39mgraph\n\u001b[1;32m     20\u001b[0m node_errors \u001b[39m=\u001b[39m get_vertex_errors(gt_nx_graph, pred_nx_graph, det_matrices)\n\u001b[0;32m---> 21\u001b[0m edge_errors \u001b[39m=\u001b[39m get_edge_errors(gt_nx_graph, pred_nx_graph, mapper)\n\u001b[1;32m     23\u001b[0m track_events \u001b[39m=\u001b[39m TrackEvents(\n\u001b[1;32m     24\u001b[0m     fp_nodes\u001b[39m=\u001b[39mnode_errors[\u001b[39m\"\u001b[39m\u001b[39mfp_nodes\u001b[39m\u001b[39m\"\u001b[39m],\n\u001b[1;32m     25\u001b[0m     fn_nodes\u001b[39m=\u001b[39mnode_errors[\u001b[39m\"\u001b[39m\u001b[39mfn_nodes\u001b[39m\u001b[39m\"\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     29\u001b[0m     incorrect_semantics\u001b[39m=\u001b[39medge_errors[\u001b[39m\"\u001b[39m\u001b[39mws_edges\u001b[39m\u001b[39m\"\u001b[39m],\n\u001b[1;32m     30\u001b[0m )\n\u001b[1;32m     31\u001b[0m \u001b[39mreturn\u001b[39;00m track_events\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/track_errors/_ctc.py:131\u001b[0m, in \u001b[0;36mget_edge_errors\u001b[0;34m(gt_graph, comp_graph, node_mapping)\u001b[0m\n\u001b[1;32m    129\u001b[0m source, target \u001b[39m=\u001b[39m edge[\u001b[39m0\u001b[39m], edge[\u001b[39m1\u001b[39m]\n\u001b[1;32m    130\u001b[0m source_gt_id \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(\u001b[39mfilter\u001b[39m(\u001b[39mlambda\u001b[39;00m mp: mp[\u001b[39m1\u001b[39m] \u001b[39m==\u001b[39m source, node_mapping))[\u001b[39m0\u001b[39m][\u001b[39m0\u001b[39m]\n\u001b[0;32m--> 131\u001b[0m target_gt_id \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39;49m(\u001b[39mfilter\u001b[39;49m(\u001b[39mlambda\u001b[39;49;00m mp: mp[\u001b[39m1\u001b[39;49m] \u001b[39m==\u001b[39;49m target, node_mapping))[\u001b[39m0\u001b[39m][\u001b[39m0\u001b[39m]\n\u001b[1;32m    132\u001b[0m expected_gt_edge \u001b[39m=\u001b[39m (source_gt_id, target_gt_id)\n\u001b[1;32m    133\u001b[0m \u001b[39mif\u001b[39;00m expected_gt_edge \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m gt_graph\u001b[39m.\u001b[39medges:\n",
-      "File \u001b[0;32m~/PhD/code/repos/cell-tracking-metrics/src/traccuracy/track_errors/_ctc.py:131\u001b[0m, in \u001b[0;36mget_edge_errors.<locals>.<lambda>\u001b[0;34m(mp)\u001b[0m\n\u001b[1;32m    129\u001b[0m source, target \u001b[39m=\u001b[39m edge[\u001b[39m0\u001b[39m], edge[\u001b[39m1\u001b[39m]\n\u001b[1;32m    130\u001b[0m source_gt_id \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(\u001b[39mfilter\u001b[39m(\u001b[39mlambda\u001b[39;00m mp: mp[\u001b[39m1\u001b[39m] \u001b[39m==\u001b[39m source, node_mapping))[\u001b[39m0\u001b[39m][\u001b[39m0\u001b[39m]\n\u001b[0;32m--> 131\u001b[0m target_gt_id \u001b[39m=\u001b[39m \u001b[39mlist\u001b[39m(\u001b[39mfilter\u001b[39m(\u001b[39mlambda\u001b[39;00m mp: mp[\u001b[39m1\u001b[39m] \u001b[39m==\u001b[39m target, node_mapping))[\u001b[39m0\u001b[39m][\u001b[39m0\u001b[39m]\n\u001b[1;32m    132\u001b[0m expected_gt_edge \u001b[39m=\u001b[39m (source_gt_id, target_gt_id)\n\u001b[1;32m    133\u001b[0m \u001b[39mif\u001b[39;00m expected_gt_edge \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m gt_graph\u001b[39m.\u001b[39medges:\n",
-      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+      "{   'CTCMetrics': {   'AOGM': 631.5,\n",
+      "                      'DET': 0.9954855886097927,\n",
+      "                      'TRA': 0.9936361895740329,\n",
+      "                      'fn_edges': 87,\n",
+      "                      'fn_nodes': 39,\n",
+      "                      'fp_edges': 60,\n",
+      "                      'fp_nodes': 0,\n",
+      "                      'ns_nodes': 0,\n",
+      "                      'ws_edges': 51},\n",
+      "    'DivisionMetrics': {   'Frame Buffer 0': {   'Division F1': 0.76,\n",
+      "                                                 'Division Precision': 0.7169811320754716,\n",
+      "                                                 'Division Recall': 0.8085106382978723,\n",
+      "                                                 'False Negative Divisions': 18,\n",
+      "                                                 'False Positive Divisions': 30,\n",
+      "                                                 'Mitotic Branching Correctness': 0.6129032258064516,\n",
+      "                                                 'Total GT Divisions': 94,\n",
+      "                                                 'True Positive Divisions': 76},\n",
+      "                           'Frame Buffer 1': {   'Division F1': 0.76,\n",
+      "                                                 'Division Precision': 0.7169811320754716,\n",
+      "                                                 'Division Recall': 0.8085106382978723,\n",
+      "                                                 'False Negative Divisions': 18,\n",
+      "                                                 'False Positive Divisions': 30,\n",
+      "                                                 'Mitotic Branching Correctness': 0.6129032258064516,\n",
+      "                                                 'Total GT Divisions': 94,\n",
+      "                                                 'True Positive Divisions': 76},\n",
+      "                           'Frame Buffer 2': {   'Division F1': 0.76,\n",
+      "                                                 'Division Precision': 0.7169811320754716,\n",
+      "                                                 'Division Recall': 0.8085106382978723,\n",
+      "                                                 'False Negative Divisions': 18,\n",
+      "                                                 'False Positive Divisions': 30,\n",
+      "                                                 'Mitotic Branching Correctness': 0.6129032258064516,\n",
+      "                                                 'Total GT Divisions': 94,\n",
+      "                                                 'True Positive Divisions': 76}}}\n"
      ]
     }
    ],
@@ -178,9 +198,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'DivisionMetrics': {   'Frame Buffer 0': {   'Division F1': 0,\n",
+      "                                                 'Division Precision': 0.0,\n",
+      "                                                 'Division Recall': 0.0,\n",
+      "                                                 'False Negative Divisions': 94,\n",
+      "                                                 'False Positive Divisions': 93,\n",
+      "                                                 'Mitotic Branching Correctness': 0.0,\n",
+      "                                                 'Total GT Divisions': 94,\n",
+      "                                                 'True Positive Divisions': 0},\n",
+      "                           'Frame Buffer 1': {   'Division F1': 0.44837758112094395,\n",
+      "                                                 'Division Precision': 0.44970414201183434,\n",
+      "                                                 'Division Recall': 0.4470588235294118,\n",
+      "                                                 'False Negative Divisions': 94,\n",
+      "                                                 'False Positive Divisions': 93,\n",
+      "                                                 'Mitotic Branching Correctness': 0.2889733840304182,\n",
+      "                                                 'Total GT Divisions': 94,\n",
+      "                                                 'True Positive Divisions': 76},\n",
+      "                           'Frame Buffer 2': {   'Division F1': 0.44837758112094395,\n",
+      "                                                 'Division Precision': 0.44970414201183434,\n",
+      "                                                 'Division Recall': 0.4470588235294118,\n",
+      "                                                 'False Negative Divisions': 94,\n",
+      "                                                 'False Positive Divisions': 93,\n",
+      "                                                 'Mitotic Branching Correctness': 0.2889733840304182,\n",
+      "                                                 'Total GT Divisions': 94,\n",
+      "                                                 'True Positive Divisions': 76}}}\n"
+     ]
+    }
+   ],
    "source": [
     "iou_results = run_metrics(\n",
     "    gt_data=gt_data, \n",
@@ -214,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.10.9"
   },
   "orig_nbformat": 4
  },

--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import networkx as nx
 import numpy as np
 from tqdm import tqdm
@@ -30,7 +28,6 @@ class CTCMatched(Matched):
         Returns:
             list[(gt_node, pred_node)]: list of tuples where each tuple contains a gt node
             and pred node
-            dict: dictionary containing detection_matrices and mappings indexed by frame_key
 
         Raises:
             ValueError: gt and pred must be a TrackingData object
@@ -82,14 +79,6 @@ class CTCMatched(Matched):
             )
             pred_label_to_id = {v: k for k, v in pred_labels.items()}
 
-            # make dictionary from label to ID so we know where in matrix to assign matches
-            # gt_label_to_id = {v: (k, i) for i, (k, v) in enumerate(gt_labels.items())}
-            # pred_label_to_id = {
-            #     v: (k, i) for i, (k, v) in enumerate(pred_labels.items())
-            # }
-            # frame_det_matrix = np.zeros(
-            #     (len(pred_frame_nodes), len(gt_frame_nodes)), dtype=np.uint8
-            # )
             overlapping_gt_labels, overlapping_pred_labels = get_labels_with_overlap(
                 gt_frame, pred_frame
             )
@@ -102,77 +91,7 @@ class CTCMatched(Matched):
                     mapping.append(
                         (gt_label_to_id[gt_label], pred_label_to_id[pred_label])
                     )
-            # populate_det_matrix(
-            #     frame_det_matrix,
-            #     gt_frame,
-            #     res_frame,
-            #     overlapping_gt_labels,
-            #     overlapping_res_labels,
-            #     gt_label_to_id,
-            #     pred_label_to_id,
-            # )
-
-            # ordered_gt_node_ids = [
-            #     v[0] for v in sorted(gt_label_to_id.values(), key=lambda x: x[1])
-            # ]
-            # ordered_comp_node_ids = [
-            #     v[0] for v in sorted(pred_label_to_id.values(), key=lambda x: x[1])
-            # ]
-
-            # det_matrices[t] = {
-            #     "det": frame_det_matrix,
-            #     "comp_ids": ordered_comp_node_ids,
-            #     "gt_ids": ordered_gt_node_ids,
-            # }
-        # matching = get_node_matching_map(det_matrices)
         return mapping
-
-
-def populate_det_matrix(
-    frame_matrix,
-    gt_frame,
-    pred_frame,
-    gt_labels,
-    res_labels,
-    gt_label_to_id,
-    res_label_to_id,
-):
-    for i in range(len(gt_labels)):
-        gt_label = gt_labels[i]
-        res_label = res_labels[i]
-        gt_blob_mask = gt_frame == gt_label
-        comp_blob_mask = pred_frame == res_label
-        is_match = int(detection_test(gt_blob_mask, comp_blob_mask))
-        if is_match:
-            pred_idx = res_label_to_id[res_label][1]
-            gt_idx = gt_label_to_id[gt_label][1]
-            frame_matrix[pred_idx, gt_idx] = is_match
-
-
-def get_node_matching_map(detection_matrices: "Dict"):
-    """Return list of tuples of (gt_id, comp_id) for all matched nodes
-
-    Parameters
-    ----------
-    detection_matrices : Dict
-        Dictionary indexed by t holding `det`, `comp_ids` and `gt_ids`
-
-    Returns
-    -------
-    matched_nodes: List[Tuple[int, int]]
-        List of tuples (gt_node_id, comp_node_id) denoting matched nodes
-        between reference graph and computed graph
-    """
-    matched_nodes = []
-    for m_dict in detection_matrices.values():
-        matrix = m_dict["det"]
-        comp_nodes = np.asarray(m_dict["comp_ids"])
-        gt_nodes = np.asarray(m_dict["gt_ids"])
-        row_idx, col_idx = np.nonzero(matrix)
-        comp_node_ids = comp_nodes[row_idx]
-        gt_node_ids = gt_nodes[col_idx]
-        matched_nodes.extend(list(zip(gt_node_ids, comp_node_ids)))
-    return matched_nodes
 
 
 def detection_test(gt_blob: "np.ndarray", comp_blob: "np.ndarray") -> int:

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -5,7 +5,6 @@ from ..matchers._matched import Matched
 
 class Metric(ABC):
     # Mapping criteria
-    needs_det_matrix = False
     needs_one_to_one = False
     supports_one_to_many = False
     supports_many_to_one = False

--- a/src/traccuracy/metrics/_ctc.py
+++ b/src/traccuracy/metrics/_ctc.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 class AOGMMetrics(Metric):
-    needs_det_matrix = True
+    supports_many_to_one = True
 
     def __init__(
         self,
@@ -37,9 +37,8 @@ class AOGMMetrics(Metric):
         gt_graph = self.data.gt_data.tracking_graph
         pred_graph = self.data.pred_data.tracking_graph
         mapping = self.data.mapping
-        matrices = self.data._det_matrices
 
-        track_events = evaluate_ctc_events(gt_graph, pred_graph, mapping, matrices)
+        track_events = evaluate_ctc_events(gt_graph, pred_graph, mapping)
         vertex_error_counts = {
             "ns": track_events.nonsplit_vertices_count,
             "fp": track_events.fp_node_count,

--- a/src/traccuracy/track_errors/_ctc.py
+++ b/src/traccuracy/track_errors/_ctc.py
@@ -52,8 +52,8 @@ def get_vertex_errors(
     nx.set_node_attributes(comp_graph, True, "is_fp")
     nx.set_node_attributes(gt_graph, True, "is_fn")
 
-    # comp:gt is useful for ns
-    # gt:comp is always going to just be one to one so we should do comp:gt
+    # we need to know how many computed vertices are "non-split", so we make
+    # a mapping of gt vertices to their matched comp vertices
     dict_mapping = defaultdict(list)
     for gt_id, pred_id in mapping:
         dict_mapping[pred_id].append(gt_id)

--- a/tests/matchers/test_ctc.py
+++ b/tests/matchers/test_ctc.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 from traccuracy._tracking_data import TrackingData
 from traccuracy._tracking_graph import TrackingGraph
-from traccuracy.matchers._ctc import CTCMatched, get_node_matching_map
+from traccuracy.matchers._ctc import CTCMatched
 
 from tests.test_utils import get_annotated_movie
 
@@ -55,37 +55,3 @@ def test_match_ctc():
     # gt and pred node should be the same
     for pair in matched.mapping:
         assert pair[0] == pair[1]
-
-    # there should be something saved in detection matrices
-    assert matched._det_matrices
-
-
-def test_get_node_matching_map():
-    comp_ids = [3, 7, 10]
-    gt_ids = [4, 12, 14, 15]
-    mtrix = np.zeros((3, 4), dtype=np.uint8)
-    mtrix[0, 1] = 1
-    mtrix[0, 3] = 1
-    mtrix[1, 2] = 1
-    mtrix_dict = {0: {"det": mtrix, "comp_ids": comp_ids, "gt_ids": gt_ids}}
-    matching = get_node_matching_map(mtrix_dict)
-    assert matching == [(12, 3), (15, 3), (14, 7)]
-
-
-def test_get_node_matching_map_multiple_frames():
-    comp_ids = [3, 7, 10]
-    gt_ids = [4, 12, 14, 15]
-    mtrix = np.zeros((3, 4), dtype=np.uint8)
-    mtrix[0, 1] = 1
-    mtrix[0, 3] = 1
-    mtrix[1, 2] = 1
-
-    mtrix2 = np.zeros((3, 4), dtype=np.uint8)
-    mtrix2[1, 1] = 1
-    mtrix2[2, 0] = 1
-    mtrix_dict = {
-        0: {"det": mtrix, "comp_ids": comp_ids, "gt_ids": gt_ids},
-        1: {"det": mtrix2, "comp_ids": comp_ids, "gt_ids": gt_ids},
-    }
-    matching = get_node_matching_map(mtrix_dict)
-    assert matching == [(12, 3), (15, 3), (14, 7), (12, 7), (4, 10)]

--- a/tests/track_errors/test_ctc_errors.py
+++ b/tests/track_errors/test_ctc_errors.py
@@ -13,24 +13,14 @@ def test_get_vertex_errors():
     gt_ids = [4, 12, 14, 17]
     gt_ids_2 = list(np.asarray(gt_ids) + 1)
 
-    mtrix = np.zeros((3, 4), dtype=np.uint8)
-    mtrix[0, 1] = 1
-    mtrix[0, 3] = 1
-    mtrix[1, 2] = 1
+    mapping = [(12, 3), (17, 3), (14, 7), (13, 8), (5, 11)]
 
-    mtrix2 = np.zeros((3, 4), dtype=np.uint8)
-    mtrix2[1, 1] = 1
-    mtrix2[2, 0] = 1
-    mtrix_dict = {
-        0: {"det": mtrix, "comp_ids": comp_ids, "gt_ids": gt_ids},
-        1: {"det": mtrix2, "comp_ids": comp_ids_2, "gt_ids": gt_ids_2},
-    }
     gt_g = nx.DiGraph()
     gt_g.add_nodes_from(gt_ids + gt_ids_2)
     comp_g = nx.DiGraph()
     comp_g.add_nodes_from(comp_ids + comp_ids_2)
 
-    vertex_errors = get_vertex_errors(gt_g, comp_g, mtrix_dict)
+    vertex_errors = get_vertex_errors(gt_g, comp_g, mapping)
     assert vertex_errors["ns"] == 1
     assert vertex_errors["tp"] == 3
     assert vertex_errors["fp"] == 2


### PR DESCRIPTION
The original AOGM paper uses "detection matrices" to allow for quick error counting. However, because we are assigning `tp`/`fp` etc. attributes to each node, we don't benefit from this quick counting - we still have to iterate through the graph.

This PR removes the reliance on detection matrices and computes the errors directly on the mapping. This should also mean we can use the AOGM/CTC metric with other matchers, assuming they are one-to-one or many-to-one (can't do one-to-many).