### PR TITLE
Faster matchings/metrics

### DIFF
--- a/src/traccuracy/loaders/_ctc.py
+++ b/src/traccuracy/loaders/_ctc.py
@@ -198,7 +198,7 @@ def load_ctc_data(data_dir, track_path=None):
     detections = get_node_attributes(masks)
 
     G = ctc_to_graph(tracks, detections)
-
+        
     data = TrackingData(TrackingGraph(G), segmentation=masks)
 
     return data

--- a/src/traccuracy/loaders/_ctc.py
+++ b/src/traccuracy/loaders/_ctc.py
@@ -198,7 +198,7 @@ def load_ctc_data(data_dir, track_path=None):
     detections = get_node_attributes(masks)
 
     G = ctc_to_graph(tracks, detections)
-        
+
     data = TrackingData(TrackingGraph(G), segmentation=masks)
 
     return data

--- a/src/traccuracy/matchers/_compute_overlap.py
+++ b/src/traccuracy/matchers/_compute_overlap.py
@@ -29,9 +29,8 @@ def get_labels_with_overlap(gt_frame, res_frame):
         overlapping_res_labels: List[int], labels of res boxes that overlap with gt boxes
         intersections: List[float], list of (intersection gt vs res) / (gt area)
     """
-    gt_frame, res_frame = gt_frame.astype(np.uint16, copy=False), res_frame.astype(
-        np.uint16, copy=False
-    )
+    gt_frame = gt_frame.astype(np.uint16, copy=False)
+    res_frame = res_frame.astype(np.uint16, copy=False)
     gt_props = regionprops(gt_frame)
     gt_boxes = [np.array(gt_prop.bbox) for gt_prop in gt_props]
     gt_boxes = np.array(gt_boxes).astype(np.float64)

--- a/src/traccuracy/matchers/_compute_overlap.py
+++ b/src/traccuracy/matchers/_compute_overlap.py
@@ -5,11 +5,13 @@ Written by Sergey Karayev
 Licensed under The MIT License [see LICENSE for details]
 Copyright (c) 2015 Microsoft
 """
+from typing import Tuple
+
 import numpy as np
 from skimage.measure import regionprops
 
 
-def _union_slice(a: tuple[slice], b: tuple[slice]):
+def _union_slice(a: Tuple[slice], b: Tuple[slice]):
     """returns the union of slice tuples a and b"""
     starts = tuple(min(_a.start, _b.start) for _a, _b in zip(a, b))
     stops = tuple(max(_a.stop, _b.stop) for _a, _b in zip(a, b))
@@ -27,7 +29,7 @@ def get_labels_with_overlap(gt_frame, res_frame):
     Returns:
         overlapping_gt_labels: List[int], labels of gt boxes that overlap with res boxes
         overlapping_res_labels: List[int], labels of res boxes that overlap with gt boxes
-        intersections: List[float], list of (intersection gt vs res) / (gt area)
+        intersections_over_gt: List[float], list of (intersection gt vs res) / (gt area)
     """
     gt_frame = gt_frame.astype(np.uint16, copy=False)
     res_frame = res_frame.astype(np.uint16, copy=False)
@@ -59,16 +61,16 @@ def get_labels_with_overlap(gt_frame, res_frame):
     overlapping_gt_labels = gt_box_labels[ind_gt]
     overlapping_res_labels = res_box_labels[ind_res]
 
-    intersections = []
+    intersections_over_gt = []
     for i, j in zip(ind_gt, ind_res):
         sslice = _union_slice(gt_props[i].slice, res_props[j].slice)
         gt_mask = gt_frame[sslice] == gt_box_labels[i]
         res_mask = res_frame[sslice] == res_box_labels[j]
         area_inter = np.count_nonzero(np.logical_and(gt_mask, res_mask))
         area_gt = np.count_nonzero(gt_mask)
-        intersections.append(area_inter / area_gt)
+        intersections_over_gt.append(area_inter / area_gt)
 
-    return overlapping_gt_labels, overlapping_res_labels, intersections
+    return overlapping_gt_labels, overlapping_res_labels, intersections_over_gt
 
 
 def compute_overlap(boxes: np.ndarray, query_boxes: np.ndarray) -> np.ndarray:

--- a/src/traccuracy/matchers/_compute_overlap.py
+++ b/src/traccuracy/matchers/_compute_overlap.py
@@ -8,13 +8,14 @@ Copyright (c) 2015 Microsoft
 import numpy as np
 from skimage.measure import regionprops
 
-def _union_slice(a:tuple[slice], b:tuple[slice]):
-    """ returns the union of slice tuples a and b """
+
+def _union_slice(a: tuple[slice], b: tuple[slice]):
+    """returns the union of slice tuples a and b"""
     starts = tuple(min(_a.start, _b.start) for _a, _b in zip(a, b))
     stops = tuple(max(_a.stop, _b.stop) for _a, _b in zip(a, b))
     return tuple(slice(start, stop) for start, stop in zip(starts, stops))
-    
-    
+
+
 def get_labels_with_overlap(gt_frame, res_frame):
     """Get all labels IDs in gt_frame and res_frame whose bounding boxes
     overlap.
@@ -24,11 +25,13 @@ def get_labels_with_overlap(gt_frame, res_frame):
         res_frame (np.ndarray): result segmentation for a given frame
 
     Returns:
-        overlapping_gt_labels: List[int], labels of gt boxes that overlap with res boxes 
+        overlapping_gt_labels: List[int], labels of gt boxes that overlap with res boxes
         overlapping_res_labels: List[int], labels of res boxes that overlap with gt boxes
         intersections: List[float], list of (intersection gt vs res) / (gt area)
     """
-    gt_frame, res_frame = gt_frame.astype(np.uint16, copy=False), res_frame.astype(np.uint16, copy=False)
+    gt_frame, res_frame = gt_frame.astype(np.uint16, copy=False), res_frame.astype(
+        np.uint16, copy=False
+    )
     gt_props = regionprops(gt_frame)
     gt_boxes = [np.array(gt_prop.bbox) for gt_prop in gt_props]
     gt_boxes = np.array(gt_boxes).astype(np.float64)
@@ -56,16 +59,16 @@ def get_labels_with_overlap(gt_frame, res_frame):
     ind_res = np.asarray(ind_res, dtype=np.uint16)
     overlapping_gt_labels = gt_box_labels[ind_gt]
     overlapping_res_labels = res_box_labels[ind_res]
-    
-    intersections = [] 
+
+    intersections = []
     for i, j in zip(ind_gt, ind_res):
         sslice = _union_slice(gt_props[i].slice, res_props[j].slice)
-        gt_mask = gt_frame[sslice]==gt_box_labels[i]
-        res_mask = res_frame[sslice]==res_box_labels[j]
+        gt_mask = gt_frame[sslice] == gt_box_labels[i]
+        res_mask = res_frame[sslice] == res_box_labels[j]
         area_inter = np.count_nonzero(np.logical_and(gt_mask, res_mask))
         area_gt = np.count_nonzero(gt_mask)
-        intersections.append(area_inter/area_gt)
-        
+        intersections.append(area_inter / area_gt)
+
     return overlapping_gt_labels, overlapping_res_labels, intersections
 
 

--- a/src/traccuracy/matchers/_compute_overlap.py
+++ b/src/traccuracy/matchers/_compute_overlap.py
@@ -8,7 +8,13 @@ Copyright (c) 2015 Microsoft
 import numpy as np
 from skimage.measure import regionprops
 
-
+def _union_slice(a:tuple[slice], b:tuple[slice]):
+    """ returns the union of slice tuples a and b """
+    starts = tuple(min(_a.start, _b.start) for _a, _b in zip(a, b))
+    stops = tuple(max(_a.stop, _b.stop) for _a, _b in zip(a, b))
+    return tuple(slice(start, stop) for start, stop in zip(starts, stops))
+    
+    
 def get_labels_with_overlap(gt_frame, res_frame):
     """Get all labels IDs in gt_frame and res_frame whose bounding boxes
     overlap.
@@ -18,16 +24,19 @@ def get_labels_with_overlap(gt_frame, res_frame):
         res_frame (np.ndarray): result segmentation for a given frame
 
     Returns:
-        Tuple[List[int], List[int]]: overlapping gt labels and result labels
+        overlapping_gt_labels: List[int], labels of gt boxes that overlap with res boxes 
+        overlapping_res_labels: List[int], labels of res boxes that overlap with gt boxes
+        intersections: List[float], list of (intersection gt vs res) / (gt area)
     """
-    gt_props = regionprops(gt_frame.astype(np.uint16))
+    gt_frame, res_frame = gt_frame.astype(np.uint16, copy=False), res_frame.astype(np.uint16, copy=False)
+    gt_props = regionprops(gt_frame)
     gt_boxes = [np.array(gt_prop.bbox) for gt_prop in gt_props]
     gt_boxes = np.array(gt_boxes).astype(np.float64)
     gt_box_labels = np.asarray(
         [int(gt_prop.label) for gt_prop in gt_props], dtype=np.uint16
     )
 
-    res_props = regionprops(res_frame.astype(np.uint16))
+    res_props = regionprops(res_frame)
     res_boxes = [np.array(res_prop.bbox) for res_prop in res_props]
     res_boxes = np.array(res_boxes).astype(np.float64)
     res_box_labels = np.asarray(
@@ -47,7 +56,17 @@ def get_labels_with_overlap(gt_frame, res_frame):
     ind_res = np.asarray(ind_res, dtype=np.uint16)
     overlapping_gt_labels = gt_box_labels[ind_gt]
     overlapping_res_labels = res_box_labels[ind_res]
-    return overlapping_gt_labels, overlapping_res_labels
+    
+    intersections = [] 
+    for i, j in zip(ind_gt, ind_res):
+        sslice = _union_slice(gt_props[i].slice, res_props[j].slice)
+        gt_mask = gt_frame[sslice]==gt_box_labels[i]
+        res_mask = res_frame[sslice]==res_box_labels[j]
+        area_inter = np.count_nonzero(np.logical_and(gt_mask, res_mask))
+        area_gt = np.count_nonzero(gt_mask)
+        intersections.append(area_inter/area_gt)
+        
+    return overlapping_gt_labels, overlapping_res_labels, intersections
 
 
 def compute_overlap(boxes: np.ndarray, query_boxes: np.ndarray) -> np.ndarray:

--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -79,11 +79,12 @@ class CTCMatched(Matched):
             )
             pred_label_to_id = {v: k for k, v in pred_labels.items()}
 
-            overlapping_gt_labels, overlapping_pred_labels, intersection = get_labels_with_overlap(
-                gt_frame, pred_frame
-            )
-            
-            
+            (
+                overlapping_gt_labels,
+                overlapping_pred_labels,
+                intersection,
+            ) = get_labels_with_overlap(gt_frame, pred_frame)
+
             for i in range(len(overlapping_gt_labels)):
                 gt_label = overlapping_gt_labels[i]
                 pred_label = overlapping_pred_labels[i]
@@ -115,10 +116,7 @@ def detection_test(gt_blob: "np.ndarray", comp_blob: "np.ndarray") -> int:
     bool
         True if computed marker majority overlaps reference marker, else False.
     """
-    
     n_gt_pixels = np.sum(gt_blob)
-    
     intersection = np.logical_and(gt_blob, comp_blob)
-    
     comp_blob_matches_gt_blob = int(np.sum(intersection) > 0.5 * n_gt_pixels)
     return comp_blob_matches_gt_blob

--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -79,15 +79,15 @@ class CTCMatched(Matched):
             )
             pred_label_to_id = {v: k for k, v in pred_labels.items()}
 
-            overlapping_gt_labels, overlapping_pred_labels = get_labels_with_overlap(
+            overlapping_gt_labels, overlapping_pred_labels, intersection = get_labels_with_overlap(
                 gt_frame, pred_frame
             )
+            
+            
             for i in range(len(overlapping_gt_labels)):
                 gt_label = overlapping_gt_labels[i]
                 pred_label = overlapping_pred_labels[i]
-                gt_blob_mask = gt_frame == gt_label
-                comp_blob_mask = pred_frame == pred_label
-                if detection_test(gt_blob_mask, comp_blob_mask):
+                if intersection[i] > 0.5:
                     mapping.append(
                         (gt_label_to_id[gt_label], pred_label_to_id[pred_label])
                     )
@@ -115,7 +115,10 @@ def detection_test(gt_blob: "np.ndarray", comp_blob: "np.ndarray") -> int:
     bool
         True if computed marker majority overlaps reference marker, else False.
     """
+    
     n_gt_pixels = np.sum(gt_blob)
+    
     intersection = np.logical_and(gt_blob, comp_blob)
+    
     comp_blob_matches_gt_blob = int(np.sum(intersection) > 0.5 * n_gt_pixels)
     return comp_blob_matches_gt_blob

--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -88,6 +88,7 @@ class CTCMatched(Matched):
             for i in range(len(overlapping_gt_labels)):
                 gt_label = overlapping_gt_labels[i]
                 pred_label = overlapping_pred_labels[i]
+# CTC metrics only match comp IDs to a single GT ID if there is majority overlap
                 if intersection[i] > 0.5:
                     mapping.append(
                         (gt_label_to_id[gt_label], pred_label_to_id[pred_label])

--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -88,7 +88,7 @@ class CTCMatched(Matched):
             for i in range(len(overlapping_gt_labels)):
                 gt_label = overlapping_gt_labels[i]
                 pred_label = overlapping_pred_labels[i]
-# CTC metrics only match comp IDs to a single GT ID if there is majority overlap
+                # CTC metrics only match comp IDs to a single GT ID if there is majority overlap
                 if intersection[i] > 0.5:
                     mapping.append(
                         (gt_label_to_id[gt_label], pred_label_to_id[pred_label])

--- a/src/traccuracy/matchers/_iou.py
+++ b/src/traccuracy/matchers/_iou.py
@@ -24,7 +24,7 @@ def _match_nodes(gt, res, threshold=1):
     """
     iou = np.zeros((np.max(gt) + 1, np.max(res) + 1))
 
-    overlapping_gt_labels, overlapping_res_labels = get_labels_with_overlap(gt, res)
+    overlapping_gt_labels, overlapping_res_labels, _ = get_labels_with_overlap(gt, res)
 
     for index in range(len(overlapping_gt_labels)):
         iou_gt_idx = overlapping_gt_labels[index]

--- a/src/traccuracy/track_errors/_ctc.py
+++ b/src/traccuracy/track_errors/_ctc.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-import numpy as np
 import networkx as nx
+import numpy as np
 from tqdm import tqdm
 
 from ._track_events import TrackEvents
@@ -114,14 +114,14 @@ def get_edge_errors(gt_graph, comp_graph, node_mapping):
 
     node_mapping_first = np.array([mp[0] for mp in node_mapping])
     node_mapping_second = np.array([mp[1] for mp in node_mapping])
-    
+
     # fp edges - edges in induced_graph that aren't in gt_graph
     for edge in tqdm(induced_graph.edges, "Evaluating FP edges"):
         source, target = edge[0], edge[1]
-        
-        source_gt_id = node_mapping[np.where(node_mapping_second==source)[0][0]][0]
-        target_gt_id = node_mapping[np.where(node_mapping_second==target)[0][0]][0]
-        
+
+        source_gt_id = node_mapping[np.where(node_mapping_second == source)[0][0]][0]
+        target_gt_id = node_mapping[np.where(node_mapping_second == target)[0][0]][0]
+
         expected_gt_edge = (source_gt_id, target_gt_id)
         if expected_gt_edge not in gt_graph.edges:
             comp_graph.edges[edge]["is_fp"] = True
@@ -145,9 +145,9 @@ def get_edge_errors(gt_graph, comp_graph, node_mapping):
             fn_edges.append(edge)
             continue
 
-        source_comp_id = node_mapping[np.where(node_mapping_first==source)[0][0]][1]
-        target_comp_id = node_mapping[np.where(node_mapping_first==target)[0][0]][1]
-        
+        source_comp_id = node_mapping[np.where(node_mapping_first == source)[0][0]][1]
+        target_comp_id = node_mapping[np.where(node_mapping_first == target)[0][0]][1]
+
         expected_comp_edge = (source_comp_id, target_comp_id)
         if expected_comp_edge not in induced_graph.edges:
             gt_graph.edges[edge]["is_fn"] = True

--- a/src/traccuracy/track_errors/_ctc.py
+++ b/src/traccuracy/track_errors/_ctc.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+import numpy as np
 import networkx as nx
 from tqdm import tqdm
 
@@ -111,11 +112,16 @@ def get_edge_errors(gt_graph, comp_graph, node_mapping):
     fn_edges = []
     ws_edges = []
 
+    node_mapping_first = np.array([mp[0] for mp in node_mapping])
+    node_mapping_second = np.array([mp[1] for mp in node_mapping])
+    
     # fp edges - edges in induced_graph that aren't in gt_graph
     for edge in tqdm(induced_graph.edges, "Evaluating FP edges"):
         source, target = edge[0], edge[1]
-        source_gt_id = list(filter(lambda mp: mp[1] == source, node_mapping))[0][0]
-        target_gt_id = list(filter(lambda mp: mp[1] == target, node_mapping))[0][0]
+        
+        source_gt_id = node_mapping[np.where(node_mapping_second==source)[0][0]][0]
+        target_gt_id = node_mapping[np.where(node_mapping_second==target)[0][0]][0]
+        
         expected_gt_edge = (source_gt_id, target_gt_id)
         if expected_gt_edge not in gt_graph.edges:
             comp_graph.edges[edge]["is_fp"] = True
@@ -139,8 +145,9 @@ def get_edge_errors(gt_graph, comp_graph, node_mapping):
             fn_edges.append(edge)
             continue
 
-        source_comp_id = list(filter(lambda mp: mp[0] == source, node_mapping))[0][1]
-        target_comp_id = list(filter(lambda mp: mp[0] == target, node_mapping))[0][1]
+        source_comp_id = node_mapping[np.where(node_mapping_first==source)[0][0]][1]
+        target_comp_id = node_mapping[np.where(node_mapping_first==target)[0][0]][1]
+        
         expected_comp_edge = (source_comp_id, target_comp_id)
         if expected_comp_edge not in induced_graph.edges:
             gt_graph.edges[edge]["is_fn"] = True


### PR DESCRIPTION
Thanks a lot for this nice package, its really great to finally have proper tracking metrics in python! 

I noticed that `run_metrics` is relatively slow for medium sized datasets (e.g. ~30s for the hela demo dataset) so this PR just add some small code changes that should improve the metrics calculations by a factor of 6-10x. 
Specifically:

- iou/overlap caluclation on slices rather than the full segmentations masks 
- vectorization of edge indexing 

With that the following 

```python 
from traccuracy import run_metrics
from traccuracy.loaders import load_ctc_data
from traccuracy.matchers import CTCMatched, IOUMatched
from traccuracy.metrics import CTCMetrics, DivisionMetrics
from timeit import default_timer


gt_data = load_ctc_data(
    'downloads/Fluo-N2DL-HeLa/01_GT/TRA',
    'downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt'
)
pred_data = load_ctc_data(
    'sample-data/Fluo-N2DL-HeLa/01_RES', 
    'sample-data/Fluo-N2DL-HeLa/01_RES/res_track.txt'
)

t = default_timer()

ctc_results = run_metrics(
    gt_data=gt_data, 
    pred_data=pred_data, 
    matcher=CTCMatched, 
    metrics=[CTCMetrics, DivisionMetrics],
    metrics_kwargs=dict(
        frame_buffer=(0,1,2)
    )
)

t = default_timer() - t

print(f'took {t:.4} s')

```

gave me `3.2s` (new) vs `26.4s` (old)







