### PR TITLE
Add basic set of performance benchmarking tests

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run benchmark
         run: |
-          pytest tests/bench.py --benchmark-json output.json
+          pytest tests/bench.py --benchmark-min-rounds=1 --benchmark-json output.json
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Run benchmark
         run: |
-          pytest tests/bench.py --benchmark-min-rounds=1 --benchmark-json output.json
+          pytest tests/bench.py --benchmark-json output.json
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -1,0 +1,43 @@
+# Do not run this workflow on pull request since this workflow has permission to modify contents.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+
+jobs:
+  benchmark:
+    name: Report benchmarks on gh-pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache-dependency-path: "pyproject.toml"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e .[test]
+
+      - name: Run benchmark
+        run: |
+          pytest tests/bench.py --benchmark-json output.json
+
+      - name: Store benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Python Benchmark with pytest-benchmark
+          tool: 'pytest'
+          output-file-path: output.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,25 @@ jobs:
       - name: Test
         run: pytest --color=yes #--cov --cov-report=xml --cov-report=term-missing
 
+      - name: Run benchmark
+        run: |
+          cd tests
+          pytest bench.py --benchmark-json output.json
+
+      - name: Store benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Python Benchmark with pytest-benchmark
+          tool: 'pytest'
+          output-file-path: tests/output.json
+          external-data-json-path: ./cache/benchmark-data.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          summary-always: true
+
       # - name: Coverage
       #   uses: codecov/codecov-action@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run benchmark
         run: |
-          pytest tests/bench.py --benchmark-json output.json
+          pytest tests/bench.py --benchmark-min-rounds=1 --benchmark-json output.json
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,15 +68,14 @@ jobs:
 
       - name: Run benchmark
         run: |
-          cd tests
-          pytest bench.py --benchmark-json output.json
+          pytest tests/bench.py --benchmark-json output.json
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: Python Benchmark with pytest-benchmark
           tool: 'pytest'
-          output-file-path: tests/output.json
+          output-file-path: output.json
           external-data-json-path: ./cache/benchmark-data.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # auto-push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Run benchmark
         run: |
-          pytest tests/bench.py --benchmark-min-rounds=1 --benchmark-json output.json
+          pytest tests/bench.py --benchmark-json output.json
 
       - name: Store benchmark results
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,28 @@ jobs:
       - name: Test
         run: pytest --color=yes #--cov --cov-report=xml --cov-report=term-missing
 
+      # - name: Coverage
+      #   uses: codecov/codecov-action@v3
+
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+          cache-dependency-path: "pyproject.toml"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e .[test]
+
       - name: Run benchmark
         run: |
           cd tests
@@ -62,9 +84,6 @@ jobs:
           alert-threshold: '200%'
           comment-on-alert: true
           summary-always: true
-
-      # - name: Coverage
-      #   uses: codecov/codecov-action@v3
 
   deploy:
     name: Deploy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,9 @@ filterwarnings = [
     "error",
     "ignore:Numba not installed, falling back to slower:UserWarning",
 ]
+addopts = [
+    "--benchmark-min-rounds=1"
+]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-test = ["pytest>=6.0", "pytest-cov", "pytest-benchmark"]
+test = ["pytest>=6.0", "pytest-cov", "pytest-benchmark", "pytest-timeout"]
 dev = [
     "black",
     "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-test = ["pytest>=6.0", "pytest-cov"]
+test = ["pytest>=6.0", "pytest-cov", "pytest-benchmark"]
 dev = [
     "black",
     "ipython",

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -91,6 +91,7 @@ def test_ctc_matched(benchmark, gt_data, pred_data):
     benchmark(CTCMatched, gt_data, pred_data)
 
 
+@pytest.mark.timeout(300)
 def test_ctc_metrics(benchmark, ctc_matched):
     def run_compute():
         return CTCMetrics(copy.deepcopy(ctc_matched)).compute()

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -1,0 +1,116 @@
+import copy
+import os
+import urllib.request
+import zipfile
+
+import pytest
+from traccuracy.loaders import load_ctc_data
+from traccuracy.matchers import CTCMatched, IOUMatched
+from traccuracy.metrics import CTCMetrics, DivisionMetrics
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+@pytest.fixture
+def gt_data():
+    # Download GT data -- look into cacheing this in github actions
+    url = "http://data.celltrackingchallenge.net/training-datasets/Fluo-N2DL-HeLa.zip"
+    data_dir = "downloads"
+
+    if not os.path.exists(data_dir):
+        os.mkdir(data_dir)
+
+    filename = url.split("/")[-1]
+    file_path = os.path.join(data_dir, filename)
+
+    if not os.path.exists(file_path):
+        urllib.request.urlretrieve(url, file_path)
+
+        # Unzip the data
+        with zipfile.ZipFile(file_path, "r") as zip_ref:
+            zip_ref.extractall(data_dir)
+
+    return load_ctc_data(
+        "downloads/Fluo-N2DL-HeLa/01_GT/TRA",
+        "downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt",
+    )
+
+
+@pytest.fixture
+def pred_data():
+    return load_ctc_data(
+        os.path.join(ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES"),
+        os.path.join(
+            ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES/res_track.txt"
+        ),
+    )
+
+
+@pytest.fixture
+def ctc_matched(gt_data, pred_data):
+    return CTCMatched(gt_data, pred_data)
+
+
+@pytest.fixture
+def iou_matched(gt_data, pred_data):
+    return IOUMatched(gt_data, pred_data, iou_threshold=0.1)
+
+
+def test_load_gt_data(benchmark):
+    benchmark(
+        load_ctc_data,
+        "downloads/Fluo-N2DL-HeLa/01_GT/TRA",
+        "downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt",
+    )
+
+
+def test_load_pred_data(benchmark):
+    benchmark(
+        load_ctc_data,
+        "../examples/sample-data/Fluo-N2DL-HeLa/01_RES",
+        "../examples/sample-data/Fluo-N2DL-HeLa/01_RES/res_track.txt",
+    )
+
+
+def test_ctc_matched(benchmark, gt_data, pred_data):
+    benchmark(CTCMatched, gt_data, pred_data)
+
+
+def test_ctc_metrics(benchmark, ctc_matched):
+    def run_compute():
+        return CTCMetrics(copy.deepcopy(ctc_matched)).compute()
+
+    ctc_results = benchmark.pedantic(run_compute, rounds=1, iterations=1)
+
+    assert ctc_results["fn_edges"] == 87
+    assert ctc_results["fn_nodes"] == 39
+    assert ctc_results["fp_edges"] == 60
+    assert ctc_results["fp_nodes"] == 0
+    assert ctc_results["ns_nodes"] == 0
+    assert ctc_results["ws_edges"] == 51
+
+
+def test_ctc_div_metrics(benchmark, ctc_matched):
+    def run_compute():
+        return DivisionMetrics(copy.deepcopy(ctc_matched)).compute()
+
+    div_results = benchmark(run_compute)
+
+    assert div_results["Frame Buffer 0"]["False Negative Divisions"] == 18
+    assert div_results["Frame Buffer 0"]["False Positive Divisions"] == 30
+    assert div_results["Frame Buffer 0"]["True Positive Divisions"] == 76
+
+
+def test_iou_matched(benchmark, gt_data, pred_data):
+    benchmark(IOUMatched, gt_data, pred_data, iou_threshold=0.5)
+
+
+def test_iou_div_metrics(benchmark, iou_matched):
+    def run_compute():
+        return DivisionMetrics(copy.deepcopy(iou_matched)).compute()
+
+    div_results = benchmark(run_compute)
+
+    assert div_results["Frame Buffer 0"]["False Negative Divisions"] == 25
+    assert div_results["Frame Buffer 0"]["False Positive Divisions"] == 31
+    assert div_results["Frame Buffer 0"]["True Positive Divisions"] == 69

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -14,7 +14,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 def download_gt_data():
     # Download GT data -- look into cacheing this in github actions
     url = "http://data.celltrackingchallenge.net/training-datasets/Fluo-N2DL-HeLa.zip"
-    data_dir = "downloads"
+    data_dir = os.path.join(ROOT_DIR, "downloads")
 
     if not os.path.exists(data_dir):
         os.mkdir(data_dir)
@@ -34,8 +34,8 @@ def download_gt_data():
 def gt_data():
     download_gt_data()
     return load_ctc_data(
-        "downloads/Fluo-N2DL-HeLa/01_GT/TRA",
-        "downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt",
+        os.path.join(ROOT_DIR, "downloads/Fluo-N2DL-HeLa/01_GT/TRA"),
+        os.path.join(ROOT_DIR, "downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt"),
     )
 
 

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -71,8 +71,10 @@ def test_load_gt_data(benchmark):
 def test_load_pred_data(benchmark):
     benchmark(
         load_ctc_data,
-        "../examples/sample-data/Fluo-N2DL-HeLa/01_RES",
-        "../examples/sample-data/Fluo-N2DL-HeLa/01_RES/res_track.txt",
+        os.path.join(ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES"),
+        os.path.join(
+            ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES/res_track.txt"
+        ),
     )
 
 

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -30,7 +30,7 @@ def download_gt_data():
             zip_ref.extractall(data_dir)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def gt_data():
     download_gt_data()
     return load_ctc_data(
@@ -39,7 +39,7 @@ def gt_data():
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def pred_data():
     return load_ctc_data(
         os.path.join(ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES"),
@@ -49,32 +49,41 @@ def pred_data():
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def ctc_matched(gt_data, pred_data):
     return CTCMatched(gt_data, pred_data)
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def iou_matched(gt_data, pred_data):
     return IOUMatched(gt_data, pred_data, iou_threshold=0.1)
 
 
 def test_load_gt_data(benchmark):
     download_gt_data()
-    benchmark(
+
+    benchmark.pedantic(
         load_ctc_data,
-        "downloads/Fluo-N2DL-HeLa/01_GT/TRA",
-        "downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt",
+        args=(
+            "downloads/Fluo-N2DL-HeLa/01_GT/TRA",
+            "downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt",
+        ),
+        rounds=1,
+        iterations=1,
     )
 
 
 def test_load_pred_data(benchmark):
-    benchmark(
+    benchmark.pedantic(
         load_ctc_data,
-        os.path.join(ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES"),
-        os.path.join(
-            ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES/res_track.txt"
+        args=(
+            os.path.join(ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES"),
+            os.path.join(
+                ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES/res_track.txt"
+            ),
         ),
+        rounds=1,
+        iterations=1,
     )
 
 

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -11,8 +11,7 @@ from traccuracy.metrics import CTCMetrics, DivisionMetrics
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-@pytest.fixture
-def gt_data():
+def download_gt_data():
     # Download GT data -- look into cacheing this in github actions
     url = "http://data.celltrackingchallenge.net/training-datasets/Fluo-N2DL-HeLa.zip"
     data_dir = "downloads"
@@ -30,6 +29,10 @@ def gt_data():
         with zipfile.ZipFile(file_path, "r") as zip_ref:
             zip_ref.extractall(data_dir)
 
+
+@pytest.fixture
+def gt_data():
+    download_gt_data()
     return load_ctc_data(
         "downloads/Fluo-N2DL-HeLa/01_GT/TRA",
         "downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt",
@@ -57,6 +60,7 @@ def iou_matched(gt_data, pred_data):
 
 
 def test_load_gt_data(benchmark):
+    download_gt_data()
     benchmark(
         load_ctc_data,
         "downloads/Fluo-N2DL-HeLa/01_GT/TRA",


### PR DESCRIPTION
This PR introduces a preliminary workflow for monitoring performance as part of our CI. It uses `pytest-benchmark` and `github-action-benchmark`.

Currently it runs on the Fluo-ND2L-HeLa dataset with the sample solution graph that we have stored in `examples/sample-data` and measures the following:
- loading gt data
- loading predicted data
- IOU matching
- CTC matching
- CTC metrics
- Division metrics (on both iou matched and ctc matched)

@DragaDoncila @bentaculum @cmalinmayor let me know what you all think at least about `tests/bench.py`. I am considering this to be a pretty minimal first set of measurements just so that we have some sort of baseline to work off of, but let me know if you see anything else that we should add in this first iteration.

The testing workflow can be run locally with `pytest tests/bench.py`
<img width="1584" alt="Screen Shot 2023-10-04 at 3 55 04 PM" src="https://github.com/Janelia-Trackathon-2023/traccuracy/assets/20373588/b7314e1b-15b9-4567-92ed-e19e9b7fc3af">

For the github action, I currently am only running the benchmarking on ubuntu-latest/python 3.11 for PRs. The action should eventually compare the results to the last commit on main and summarize any changes. It may take me a couple iterations of commits to main to get the reporting component working smoothly.

Additionally, a separate workflow will run on each commit pushed to main and publish plots to gh-pages ([example](https://benchmark-action.github.io/github-action-benchmark/dev/bench/)). This workflow may also take a couple commits to be fully functional. 