### PR TITLE
Speed up accessing nodes/edges by attribute and node/edge attributes

### DIFF
--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -551,6 +551,56 @@ class TrackingGraph:
             else:
                 self.edges_by_flag[attr].discard(_id)
 
+    def get_node_attribute(self, _id, attr):
+        """Get the boolean value of a given attribute for a given node.
+
+        Args:
+            _id (hashable): node id
+            attr (NodeAttr): Node attribute to fetch the value of
+
+        Raises:
+            ValueError: if attr is not a NodeAttr
+
+        Returns:
+            bool: The value of the attribute for that node. If the attribute
+                is not present on the graph, the value is presumed False.
+        """
+        if not isinstance(attr, NodeAttr):
+            raise ValueError(
+                f"Provided attribute {attr} is not of type NodeAttr. "
+                "Please use the enum instead of passing string values, "
+                "and add new attributes to the class to avoid key collision."
+            )
+
+        if attr not in self.graph.nodes[_id]:
+            return False
+        return self.graph.nodes[_id][attr]
+
+    def get_edge_attribute(self, _id, attr):
+        """Get the boolean value of a given attribute for a given edge.
+
+        Args:
+            _id (hashable): node id
+            attr (EdgeAttr): Edge attribute to fetch the value of
+
+        Raises:
+            ValueError: if attr is not a EdgeAttr
+
+        Returns:
+            bool: The value of the attribute for that edge. If the attribute
+                is not present on the graph, the value is presumed False.
+        """
+        if not isinstance(attr, EdgeAttr):
+            raise ValueError(
+                f"Provided attribute {attr} is not of type EdgeAttr. "
+                "Please use the enum instead of passing string values, "
+                "and add new attributes to the class to avoid key collision."
+            )
+
+        if attr not in self.graph.edges[_id]:
+            return False
+        return self.graph.edges[_id][attr]
+
     def get_tracklets(self):
         """Gets a list of new TrackingGraph objects containing all tracklets of the current graph.
 

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -178,7 +178,7 @@ class TrackingGraph:
             # store node id in nodes_by_frame mapping
             frame = attrs[self.frame_key]
             if frame not in self.nodes_by_frame.keys():
-                self.nodes_by_frame[frame] = set([node])
+                self.nodes_by_frame[frame] = {node}
             else:
                 self.nodes_by_frame[frame].add(node)
             # store node id in nodes_by_flag mapping
@@ -484,9 +484,13 @@ class TrackingGraph:
                 del new_trackgraph.nodes_by_frame[frame]
 
         for attr in NodeAttr:
-            new_trackgraph.nodes_by_flag[attr] = self.nodes_by_flag[attr].intersection(nodes)
+            new_trackgraph.nodes_by_flag[attr] = self.nodes_by_flag[attr].intersection(
+                nodes
+            )
         for attr in EdgeAttr:
-            new_trackgraph.edges_by_flag[attr] = self.edges_by_flag[attr].intersection(nodes)
+            new_trackgraph.edges_by_flag[attr] = self.edges_by_flag[attr].intersection(
+                nodes
+            )
 
         new_trackgraph.start_frame = min(new_trackgraph.nodes_by_frame.keys())
         new_trackgraph.end_frame = max(new_trackgraph.nodes_by_frame.keys()) + 1

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -1,5 +1,8 @@
+from collections import Counter
+
 import networkx as nx
 import pytest
+
 from traccuracy import EdgeAttr, NodeAttr, TrackingGraph
 
 
@@ -80,10 +83,10 @@ def test_constructor(nx_comp1):
     assert tracking_graph.start_frame == 0
     assert tracking_graph.end_frame == 4
     assert tracking_graph.nodes_by_frame == {
-        0: ["1_0"],
-        1: ["1_1"],
-        2: ["1_2", "1_3"],
-        3: ["1_4"],
+        0: {"1_0"},
+        1: {"1_1"},
+        2: {"1_2", "1_3"},
+        3: {"1_4"},
     }
 
     # raise AssertionError if frame key not present or ValueError if overlaps
@@ -100,14 +103,14 @@ def test_constructor(nx_comp1):
 
 def test_get_cells_by_frame(simple_graph):
     assert simple_graph.get_nodes_in_frame(0) == ["1_0"]
-    assert simple_graph.get_nodes_in_frame(2) == ["1_2", "1_3"]
+    assert Counter(simple_graph.get_nodes_in_frame(2)) == Counter(["1_2", "1_3"])
     assert simple_graph.get_nodes_in_frame(5) == []
 
 
 def test_get_nodes_by_roi(simple_graph):
     assert simple_graph.get_nodes_by_roi(t=(0, 1)) == ["1_0"]
-    assert simple_graph.get_nodes_by_roi(x=(1, None)) == ["1_0", "1_1", "1_3", "1_4"]
-    assert simple_graph.get_nodes_by_roi(x=(None, 2), t=(1, None)) == ["1_1", "1_2"]
+    assert Counter(simple_graph.get_nodes_by_roi(x=(1, None))) == Counter(["1_0", "1_1", "1_3", "1_4"])
+    assert Counter(simple_graph.get_nodes_by_roi(x=(None, 2), t=(1, None))) == Counter(["1_1", "1_2"])
 
 
 def test_get_location(nx_comp1):
@@ -176,7 +179,7 @@ def test_get_preds(simple_graph):
 
 def test_get_succs(simple_graph):
     assert simple_graph.get_succs("1_0") == ["1_1"]
-    assert simple_graph.get_succs("1_1") == ["1_2", "1_3"]
+    assert Counter(simple_graph.get_succs("1_1")) == Counter(["1_2", "1_3"])
     assert simple_graph.get_succs("1_2") == []
 
 

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -2,7 +2,6 @@ from collections import Counter
 
 import networkx as nx
 import pytest
-
 from traccuracy import EdgeAttr, NodeAttr, TrackingGraph
 
 
@@ -109,8 +108,12 @@ def test_get_cells_by_frame(simple_graph):
 
 def test_get_nodes_by_roi(simple_graph):
     assert simple_graph.get_nodes_by_roi(t=(0, 1)) == ["1_0"]
-    assert Counter(simple_graph.get_nodes_by_roi(x=(1, None))) == Counter(["1_0", "1_1", "1_3", "1_4"])
-    assert Counter(simple_graph.get_nodes_by_roi(x=(None, 2), t=(1, None))) == Counter(["1_1", "1_2"])
+    assert Counter(simple_graph.get_nodes_by_roi(x=(1, None))) == Counter(
+        ["1_0", "1_1", "1_3", "1_4"]
+    )
+    assert Counter(simple_graph.get_nodes_by_roi(x=(None, 2), t=(1, None))) == Counter(
+        ["1_1", "1_2"]
+    )
 
 
 def test_get_location(nx_comp1):


### PR DESCRIPTION
Changes to `TrackingGraph` to improve performance related to attributes:
- Store dictionaries from NodeAttrs -> node ids and EdgeAttrs -> edge ids to efficiently access all nodes/edges with given attribute
- Use those dictionaries in `get_nodes_with_flag()`, `get_edges_with_flag()`, and `get_nodes_by_roi()`
- Speed up accessing node/edge attributes with specific functions `get_node_attribute()` and `get_edge_attribute()`, instead of having to go through `nodes()` and `edges()` dictionaries
- Speed up subgraph function by not re-computing all dictionaries from attrs to ids, but instead using intersection of sets of ids.
- Use `collections.Counter` in TrackingGraph test cases to make them order invariant
Closes #61 