### PR TITLE
Improve the benchmarking workflow to generate a commit comment on PRs

### DIFF
--- a/.github/workflows/benchmark-pr.py
+++ b/.github/workflows/benchmark-pr.py
@@ -22,9 +22,14 @@ def make_report(old_path, new_path, out_file):
     new = load_stats(new_path)
 
     # Merge on benchmark name
-    df = new[-1].merge(old[-1], on="Benchmark", suffixes=("_new", "_old"))
+    df = old[-1].merge(new[-1], on="Benchmark", suffixes=("_old", "_new"))
 
     df["Percent Change"] = 100 * (df["mean_new"] - df["mean_old"]) / df["mean_old"]
+    df["Percent Change"] = df["Percent Change"].map("{:.2f}".format)
+
+    # Format runtimes
+    df["mean_old"] = df["mean_old"].map("{:.5f}".format)
+    df["mean_new"] = df["mean_new"].map("{:.5f}".format)
 
     # Change column names to commit ids
     df = df.rename(

--- a/.github/workflows/benchmark-pr.py
+++ b/.github/workflows/benchmark-pr.py
@@ -1,0 +1,36 @@
+import json
+
+import pandas as pd
+import typer
+
+
+def load_stats(path):
+    with open(path) as f:
+        data = json.load(f)
+
+    commit = data["commit_info"]["id"]
+
+    rows = []
+    for d in data["benchmarks"]:
+        rows.append({"Benchmark": d["name"], "mean": d["stats"]["mean"]})
+
+    return commit, pd.DataFrame(rows)
+
+
+def make_report(old_path, new_path, out_file):
+    old = load_stats(old_path)
+    new = load_stats(new_path)
+
+    # Merge on benchmark name
+    df = new[-1].merge(old[-1], on="Benchmark", suffixes=("_new", "_old"))
+
+    df["Percent Change"] = (df["mean_new"] - df["mean_old"]) / df["mean_old"]
+
+    # Change column names to commit ids
+    df = df.rename(columns={"mean_new": new[0], "mean_old": old[0]})
+
+    df.to_markdown(out_file, index=False)
+
+
+if __name__ == "__main__":
+    typer.run(make_report)

--- a/.github/workflows/benchmark-pr.py
+++ b/.github/workflows/benchmark-pr.py
@@ -24,10 +24,15 @@ def make_report(old_path, new_path, out_file):
     # Merge on benchmark name
     df = new[-1].merge(old[-1], on="Benchmark", suffixes=("_new", "_old"))
 
-    df["Percent Change"] = (df["mean_new"] - df["mean_old"]) / df["mean_old"]
+    df["Percent Change"] = 100 * (df["mean_new"] - df["mean_old"]) / df["mean_old"]
 
     # Change column names to commit ids
-    df = df.rename(columns={"mean_new": new[0], "mean_old": old[0]})
+    df = df.rename(
+        columns={
+            "mean_new": f"Mean (s) HEAD {new[0]}",
+            "mean_old": f"Mean (s) BASE {old[0]}",
+        }
+    )
 
     df.to_markdown(out_file, index=False)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v3
@@ -71,6 +72,7 @@ jobs:
 
       - name: Retrieve cached baseline if available
         uses: actions/cache/restore@v3
+        id: cache
         with:
           path: baseline.json
           key: ${{ github.event.pull_request.base.sha }}
@@ -87,8 +89,6 @@ jobs:
         with:
           path: baseline.json
           key: ${{ github.event.pull_request.base.sha }}
-
-
 
       - name: Run benchmark on PR head commit
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 50 # this is to make sure we obtain the target base commit
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -65,24 +67,41 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -e .[test]
+          python -m pip install tabulate
 
-      - name: Run benchmark
-        run: |
-          pytest tests/bench.py --benchmark-json output.json
-
-      - name: Store benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
+      - name: Retrieve cached baseline if available
+        uses: actions/cache/restore@v3
         with:
-          name: Python Benchmark with pytest-benchmark
-          tool: 'pytest'
-          output-file-path: output.json
-          external-data-json-path: ./cache/benchmark-data.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # auto-push: true
-          # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'
-          comment-on-alert: true
-          summary-always: true
+          path: baseline.json
+          key: ${{ github.event.pull_request.base.sha }}
+
+      - name: Run baseline benchmark if not in cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          pytest tests/bench.py --benchmark-json baseline.json
+
+      - name: Cache baseline results
+        uses: actions/cache/save@v3
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: baseline.json
+          key: ${{ github.event.pull_request.base.sha }}
+
+
+
+      - name: Run benchmark on PR head commit
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          pytest tests/bench.py --benchmark-json pr.json
+
+      - name: Generate report
+        run: python .github/workflows/benchmark-pr.py baseline.json pr.json report.md
+
+      - name: Comment on commit with report
+        uses: peter-evans/commit-comment@v3
+        with:
+          body-path: report.md
 
   deploy:
     name: Deploy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-test = ["pytest>=6.0", "pytest-cov", "pytest-benchmark", "pytest-timeout"]
+test = ["pytest>=6.0", "pytest-cov", "pytest-benchmark", "pytest-timeout", "tabulate"]
 dev = [
     "black",
     "ipython",


### PR DESCRIPTION
I couldn't get the `github-actions-benchmark` to perform the way I wanted for PRs (although it's working great for generating the charts on github pages). Instead I wrote a slightly more manual action that I think gives us what we want.

The benchmarking action triggered for each PR now does the following:
- Checks if benchmarks have been cached for the base commit and computes and saves them if not
- Runs benchmarking for the current commit 
- Generates a table comparing the mean runtime for head and base with the percent change
- Comments on the commit with the comparison table

@bentaculum are there any other statistics that you would want to see in that table?