### PR TITLE
Improve benchmark action when running on repo forks

### DIFF
--- a/.github/workflows/benchmark-pr.py
+++ b/.github/workflows/benchmark-pr.py
@@ -41,6 +41,9 @@ def make_report(old_path, new_path, out_file):
 
     df.to_markdown(out_file, index=False)
 
+    # Print report to logs
+    print(df.to_markdown(index=False))
+
 
 if __name__ == "__main__":
     typer.run(make_report)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,9 @@ jobs:
       - name: Generate report
         run: python .github/workflows/benchmark-pr.py baseline.json pr.json report.md
 
-      - name: Comment on commit with report
+      - name: Comment on commit with report for non-forks
         uses: peter-evans/commit-comment@v3
+        if: github.event.pull_request.head.repo.fork == false
         with:
           body-path: report.md
 


### PR DESCRIPTION
See https://github.com/Janelia-Trackathon-2023/traccuracy/pull/64#issuecomment-1760249229 for a description of the issue with commenting on forked repos.

This PR changes the benchmark action to print a copy of the report to the logs so that the results are always visible. The commit comment is only generated if the source repo for the PR is not a fork.