### PR TITLE
Correct benchmarking tests assertion for wrong semantic edges

### DIFF
--- a/tests/bench.py
+++ b/tests/bench.py
@@ -103,7 +103,7 @@ def test_ctc_metrics(benchmark, ctc_matched):
     assert ctc_results["fp_edges"] == 60
     assert ctc_results["fp_nodes"] == 0
     assert ctc_results["ns_nodes"] == 0
-    assert ctc_results["ws_edges"] == 51
+    assert ctc_results["ws_edges"] == 47
 
 
 def test_ctc_div_metrics(benchmark, ctc_matched):


### PR DESCRIPTION
With the merge of #54, the benchmarking assertion about the number of wrong semantic edges in our test candidate graph changed. I'm not entirely sure why but given that we were changing how wrong semantic is assigned I am not entirely surprised. This PR corrects the assertion so that benchmarking should pass.