### PR TITLE
style: update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,24 +4,29 @@ ci:
   autoupdate_commit_msg: "ci(pre-commit.ci): autoupdate"
 
 repos:
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.254
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.16.21
+    hooks:
+      - id: typos
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.3
     hooks:
       - id: ruff
         args: [--fix]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.10.1
     hooks:
       - id: black
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.12.1
+    rev: v0.15
     hooks:
       - id: validate-pyproject
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.6.1
     hooks:
       - id: mypy
         files: "^src/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = { text = "BSD 3-Clause License" }
 authors = [
     { email = "draga.doncilapop1@monash.edu", name = "Draga Doncila Pop" },
     { email = "cmalinmayor@gmail.com", name = "Caroline Malin-Mayor" },
-    { email = "msschwartz21@gmail.com", name = "Morgan Schwartz"}
+    { email = "msschwartz21@gmail.com", name = "Morgan Schwartz" },
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -33,7 +33,7 @@ dependencies = [
     "networkx",
     "pandas",
     "tifffile",
-    "imagecodecs", # required for ctc tiffs
+    "imagecodecs",  # required for ctc tiffs
     "scikit-image",
     "tqdm",
     "typer",
@@ -44,7 +44,13 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-test = ["pytest>=6.0", "pytest-cov", "pytest-benchmark", "pytest-timeout", "tabulate"]
+test = [
+    "pytest>=6.0",
+    "pytest-cov",
+    "pytest-benchmark",
+    "pytest-timeout",
+    "tabulate",
+]
 dev = [
     "black",
     "ipython",
@@ -66,7 +72,7 @@ docs = [
     "nbsphinx-link",
     "sphinx-click",
     "ipython",
-    "docutils~=0.16.0"
+    "docutils~=0.16.0",
     # had to pin versions because of sphinx list rendering bug
     # https://stackoverflow.com/questions/67542699/readthedocs-sphinx-not-rendering-bullet-list-from-rst-file
 ]
@@ -83,7 +89,7 @@ traccuracy = "traccuracy.cli:main"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-where = ['src'] #  list of folders that contain packages
+where = ['src']           #  list of folders that contain packages
 include = ['traccuracy*']
 
 [tool.setuptools_scm] # Necessary to enable setuptools_scm for dynamic versioning from tags
@@ -106,14 +112,15 @@ extend-select = [
     "E",    # style errors
     "W",    # style warnings
     "F",    # flakes
-    # "D",    # pydocstyle
     "I",    # isort
-    "U",    # pyupgrade
-    # "S",    # bandit
-    "C",    # flake8-comprehensions
+    "UP",   # pyupgrade
+    "C4",   # flake8-comprehensions
     "B",    # flake8-bugbear
     "A001", # flake8-builtins
     "RUF",  # ruff-specific rules
+    "TID",  # tidy imports
+    "TCH",  # type checking
+    # "D",    # pydocstyle
 ]
 # I do this to get numpy-style docstrings AND retain
 # D417 (Missing argument descriptions in the docstring)
@@ -137,7 +144,8 @@ convention = "google"
 [tool.ruff.per-file-ignores]
 "tests/*.py" = ["D", "S"]
 "setup.py" = ["D"]
-"src/traccuracy/cli.py" = ["B008"]  # Ignore typer functions in function definitions
+# Ignore typer functions in function definitions
+"src/traccuracy/cli.py" = ["B008"]
 
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
@@ -147,9 +155,7 @@ filterwarnings = [
     "error",
     "ignore:Numba not installed, falling back to slower:UserWarning",
 ]
-addopts = [
-    "--benchmark-min-rounds=1"
-]
+addopts = ["--benchmark-min-rounds=1"]
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]

--- a/src/traccuracy/matchers/_compute_overlap.py
+++ b/src/traccuracy/matchers/_compute_overlap.py
@@ -170,7 +170,8 @@ except ImportError:
         warnings.warn(
             "Numba not installed, falling back to slower numpy implementation. "
             "Install numba for a significant speedup.  Set the environment "
-            "variable NO_JIT_WARNING=1 to disable this warning."
+            "variable NO_JIT_WARNING=1 to disable this warning.",
+            stacklevel=2,
         )
 else:
     # compute_overlap 2d and 3d have the same signature

--- a/src/traccuracy/matchers/_matched.py
+++ b/src/traccuracy/matchers/_matched.py
@@ -1,7 +1,9 @@
 import logging
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from traccuracy._tracking_graph import TrackingGraph
+if TYPE_CHECKING:
+    from traccuracy._tracking_graph import TrackingGraph
 
 logger = logging.getLogger(__name__)
 

--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from ..matchers._matched import Matched
+if TYPE_CHECKING:
+    from traccuracy.matchers._matched import Matched
 
 
 class Metric(ABC):

--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -1,6 +1,6 @@
 """This submodule classifies division errors in tracking graphs
 
-Each division is classifed as one of the following:
+Each division is classified as one of the following:
 - true positive
 - false positive
 - false negative
@@ -47,7 +47,7 @@ class DivisionMetrics(Metric):
 
         - Division Recall
         - Division Precision
-        - Divison F1 Score
+        - Division F1 Score
         - Mitotic Branching Correctness: TP / (TP + FP + FN) as defined by Ulicna, K.,
           Vallardi, G., Charras, G. & Lowe, A. R. Automated deep lineage tree analysis
           using a Bayesian single cell tracking approach. Frontiers in Computer Science
@@ -55,7 +55,7 @@ class DivisionMetrics(Metric):
 
         Args:
             matched_data (Matched): Matched object for set of GT and Pred data
-                Must meet the `needs_one_to_one` critera
+                Must meet the `needs_one_to_one` criteria
             frame_buffer (tuple(int), optional): Tuple of integers. Value used as n_frames
                 to tolerate in correct_shifted_divisions. Defaults to (0).
         """
@@ -63,7 +63,7 @@ class DivisionMetrics(Metric):
         super().__init__(matched_data)
 
     def compute(self):
-        """Runs `_evalute_division_events` and calculates summary metrics for each frame buffer
+        """Runs `_evaluate_division_events` and calculates summary metrics for each frame buffer
 
         Returns:
             dict: Returns a nested dictionary with one dictionary per frame buffer value

--- a/src/traccuracy/track_errors/divisions.py
+++ b/src/traccuracy/track_errors/divisions.py
@@ -32,7 +32,7 @@ def _classify_divisions(matched_data: "Matched"):
     mapper = matched_data.mapping
 
     if g_gt.division_annotations and g_pred.division_annotations:
-        logger.info("Divison annotations already present. Skipping graph annotation.")
+        logger.info("Division annotations already present. Skipping graph annotation.")
         return
 
     # Check that mapper is one to one
@@ -61,7 +61,7 @@ def _classify_divisions(matched_data: "Matched"):
         # No matching node so division missed
         if pred_node is None:
             g_gt.set_node_attribute(gt_node, NodeAttr.FN_DIV, True)
-        # Check if the division has the corret daughters
+        # Check if the division has the correct daughters
         else:
             succ_gt = g_gt.get_succs(gt_node)
             # Map pred succ nodes onto gt, unmapped nodes will return as None
@@ -183,7 +183,7 @@ def _correct_shifted_divisions(matched_data: "Matched", n_frames=1):
 
         # False positive in pred occurs before false negative in gt
         if t_fp < t_fn:
-            # Check if fp node matches prececessor of fn
+            # Check if fp node matches predecessor of fn
             fn_pred = _get_pred_by_t(g_gt, fn_node, t_fn - t_fp)
             # Check if the match exists
             if (fn_pred, fp_node) not in mapper:

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -12,7 +12,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 def download_gt_data():
-    # Download GT data -- look into cacheing this in github actions
+    # Download GT data -- look into caching this in github actions
     url = "http://data.celltrackingchallenge.net/training-datasets/Fluo-N2DL-HeLa.zip"
     data_dir = os.path.join(ROOT_DIR, "downloads")
 

--- a/tests/metrics/test_divisions.py
+++ b/tests/metrics/test_divisions.py
@@ -2,7 +2,7 @@ from traccuracy import TrackingGraph
 from traccuracy.matchers._matched import Matched
 from traccuracy.metrics._divisions import DivisionMetrics
 
-from ..test_utils import get_division_graphs
+from tests.test_utils import get_division_graphs
 
 
 class DummyMatched(Matched):

--- a/tests/track_errors/test_divisions.py
+++ b/tests/track_errors/test_divisions.py
@@ -11,7 +11,7 @@ from traccuracy.track_errors.divisions import (
     _get_succ_by_t,
 )
 
-from ..test_utils import get_division_graphs
+from tests.test_utils import get_division_graphs
 
 
 class DummyMatched(Matched):


### PR DESCRIPTION
This pr runs `pre-commit autoupdate`, to bring the linting deps up to date... and (all of these are optionally and can be removed if you like):

1. adds [the `TID` tidy-imports rule](https://docs.astral.sh/ruff/rules/#flake8-tidy-imports-tid), which enforces the absolute import patterns you've generally been following here.
2. adds [the `TCH` type-checking rule](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tch) which nicely catches cases where an import should be removed from, or moved to, an `if TYPE_CHECKING` block (it can autofix it too)
3. adds https://github.com/crate-ci/typos to the checks, which is a nice, fast, rust-based code-spelling checker (it caught and fixed few issues in the docstrings, also included here)

closes #33