### PR TITLE
Add CTC format checks in loader

### DIFF
--- a/src/traccuracy/loaders/__init__.py
+++ b/src/traccuracy/loaders/__init__.py
@@ -5,6 +5,6 @@ truth or tracking method outputs into memory as TrackingGraph objects.
 Each loading function must return one TrackingGraph object which has a
 track graph and optionally contains a corresponding segmentation.
 """
-from ._ctc import load_ctc_data
+from ._ctc import _check_ctc, _get_node_attributes, _load_tiffs, load_ctc_data
 
-__all__ = ["load_ctc_data"]
+__all__ = ["load_ctc_data", "_check_ctc", "_load_tiffs", "_get_node_attributes"]

--- a/src/traccuracy/loaders/_ctc.py
+++ b/src/traccuracy/loaders/_ctc.py
@@ -14,7 +14,7 @@ from traccuracy._tracking_graph import TrackingGraph
 logger = logging.getLogger(__name__)
 
 
-def load_tiffs(data_dir):
+def _load_tiffs(data_dir):
     """Load a directory of individual frames into a stack.
 
     Args:
@@ -55,7 +55,7 @@ def _detections_from_image(stack, idx):
     return pd.DataFrame(props)
 
 
-def get_node_attributes(masks):
+def _get_node_attributes(masks):
     """Calculates x,y,z,t,label for each detection in a movie.
 
     Args:
@@ -86,7 +86,7 @@ def ctc_to_graph(df, detections):
 
     Args:
         data (pd.DataFrame): DataFrame of CTC-style info
-        detections (pd.DataFrame): Dataframe from get_node_attributes with position
+        detections (pd.DataFrame): Dataframe from _get_node_attributes with position
             and segmentation label for each cell detection
 
     Returns:
@@ -251,8 +251,8 @@ def load_ctc_data(data_dir, track_path=None, run_checks=True):
 
     tracks = pd.read_csv(track_path, header=None, sep=" ", names=names)
 
-    masks = load_tiffs(data_dir)
-    detections = get_node_attributes(masks)
+    masks = _load_tiffs(data_dir)
+    detections = _get_node_attributes(masks)
     if run_checks:
         _check_ctc(tracks, detections, masks)
 

--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -57,7 +57,7 @@ class DivisionMetrics(Metric):
         3, 734559 (2021).
 
     Args:
-        matched_data (Matched): Matched object for set of GT and Pred data
+        matched_data (traccuracy.matchers.Matched): Matched object for set of GT and Pred data
             Must meet the `needs_one_to_one` criteria
         frame_buffer (tuple(int), optional): Tuple of integers. Value used as n_frames
             to tolerate in correct_shifted_divisions. Defaults to (0).

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -36,6 +36,7 @@ def gt_data():
     return load_ctc_data(
         os.path.join(ROOT_DIR, "downloads/Fluo-N2DL-HeLa/01_GT/TRA"),
         os.path.join(ROOT_DIR, "downloads/Fluo-N2DL-HeLa/01_GT/TRA/man_track.txt"),
+        run_checks=False,
     )
 
 
@@ -46,6 +47,7 @@ def pred_data():
         os.path.join(
             ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES/res_track.txt"
         ),
+        run_checks=False,
     )
 
 


### PR DESCRIPTION
This adds some checks to enforce proper Cell Tracking Challenge data format already while loading, and prints descriptive error messages.
As discussed in the last meeting, they are turned on by default, but can be turned off with a boolean in `load_ctc_data`.

I've been dealing with tracking results in faulty CTC format recently and ran into weird errors downstream of the loader in the metrics computation, which inspired this PR.

The proposed routine checks:
- unique positive integer track IDs
- indicated parent IDs present
- parent tracklet ends before child tracklet starts (gaps possible)
- masks contain all detections as indicated in tracks file, and vice versa.