### PR TITLE
Change `frame_buffer` kwarg to `max_frame_buffer`

### DIFF
--- a/src/traccuracy/cli.py
+++ b/src/traccuracy/cli.py
@@ -187,7 +187,7 @@ def run_divisions_on_iou(
         gt_data,
         pred_data,
         IOUMatcher(iou_threshold=match_threshold),
-        [DivisionMetrics(frame_buffer=frame_buffer_tuple)],
+        [DivisionMetrics(max_frame_buffer=frame_buffer_tuple)],
     )
     with open(out_path, "w") as fp:
         json.dump(result, fp)
@@ -242,7 +242,7 @@ def run_divisions_on_ctc(
         gt_data,
         pred_data,
         CTCMatcher(),
-        [DivisionMetrics(frame_buffer=frame_buffer_tuple)],
+        [DivisionMetrics(max_frame_buffer=frame_buffer_tuple)],
     )
     with open(out_path, "w") as fp:
         json.dump(result, fp)

--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -57,14 +57,15 @@ class DivisionMetrics(Metric):
         3, 734559 (2021).
 
     Args:
-        frame_buffer (tuple(int), optional): Tuple of integers. Value used as n_frames
-            to tolerate in correct_shifted_divisions. Defaults to (0).
+        max_frame_buffer (int, optional): Maximum value of frame buffer to use in correcting
+            shifted divisions. Divisions will be evaluated for all integer values of frame
+            buffer between 0 and max_frame_buffer
     """
 
     needs_one_to_one = True
 
-    def __init__(self, frame_buffer=(0,)):
-        self.frame_buffer = frame_buffer
+    def __init__(self, max_frame_buffer=0):
+        self.frame_buffer = max_frame_buffer
 
     def _compute(self, data: Matched):
         """Runs `_evaluate_division_events` and calculates summary metrics for each frame buffer
@@ -78,7 +79,7 @@ class DivisionMetrics(Metric):
         """
         div_annotations = _evaluate_division_events(
             data,
-            frame_buffer=self.frame_buffer,
+            max_frame_buffer=self.frame_buffer,
         )
 
         return {

--- a/src/traccuracy/track_errors/divisions.py
+++ b/src/traccuracy/track_errors/divisions.py
@@ -238,7 +238,7 @@ def _correct_shifted_divisions(matched_data: Matched, n_frames=1):
     return new_matched
 
 
-def _evaluate_division_events(matched_data: Matched, frame_buffer=(0)):
+def _evaluate_division_events(matched_data: Matched, max_frame_buffer=0):
     """Classify division errors and correct shifted divisions according to frame_buffer
 
     Note: A copy of matched_data will be created for each frame_buffer other than 0.
@@ -247,8 +247,9 @@ def _evaluate_division_events(matched_data: Matched, frame_buffer=(0)):
     Args:
         matched_data (Matched): Matched data object containing gt and pred graphs
             with their associated mapping
-        frame_buffer (tuple, optional): Tuple of integers. Value used as n_frames
-            to tolerate in correct_shifted_divisions. Defaults to (0).
+        max_frame_buffer (int, optional): Maximum value of frame buffer to use in correcting
+            shifted divisions. Divisions will be evaluated for all integer values of frame
+            buffer between 0 and max_frame_buffer
 
     Returns:
         dict {frame_buffer: matched_data}: A dictionary where each key corresponds to a frame
@@ -262,11 +263,7 @@ def _evaluate_division_events(matched_data: Matched, frame_buffer=(0)):
     div_annotations[0] = matched_data
 
     # Correct shifted divisions for each nonzero value in frame_buffer
-    for delta in frame_buffer:
-        # Skip 0 because we used that in baseline classification
-        if delta == 0:
-            continue
-
+    for delta in range(1, max_frame_buffer + 1):
         corrected_matched = _correct_shifted_divisions(matched_data, n_frames=delta)
         div_annotations[delta] = corrected_matched
 

--- a/tests/metrics/test_divisions.py
+++ b/tests/metrics/test_divisions.py
@@ -12,13 +12,13 @@ def test_DivisionMetrics():
         TrackingGraph(g_pred),
         mapper,
     )
-    frame_buffer = (0, 1, 2)
+    frame_buffer = 2
 
-    results = DivisionMetrics(frame_buffer=frame_buffer)._compute(matched)
+    results = DivisionMetrics(max_frame_buffer=frame_buffer)._compute(matched)
 
     for name, r in results.items():
         buffer = int(name[-1:])
-        assert buffer in frame_buffer
+        assert buffer in list(range(frame_buffer + 1))
         if buffer in (0, 1):
             # No corrections
             assert r["True Positive Divisions"] == 0

--- a/tests/track_errors/test_divisions.py
+++ b/tests/track_errors/test_divisions.py
@@ -213,10 +213,10 @@ class Test_correct_shifted_divisions:
 
 def test_evaluate_division_events():
     g_gt, g_pred, mapper = get_division_graphs()
-    frame_buffer = (0, 1, 2)
+    frame_buffer = 2
 
     matched_data = Matched(TrackingGraph(g_gt), TrackingGraph(g_pred), mapper)
 
-    results = _evaluate_division_events(matched_data, frame_buffer=frame_buffer)
+    results = _evaluate_division_events(matched_data, max_frame_buffer=frame_buffer)
 
     assert np.all([isinstance(k, int) for k in results.keys()])


### PR DESCRIPTION
Closes #100 by making the behavior associated with the frame buffer parameter more explicit. The user specifies the maximum size of the frame buffer and we evaluate divisions over [0, max_frame_buffer].

# Types of Changes
What types of changes does your code introduce? Put an x in the boxes that apply.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement
- [ ] Documentation update
- [ ] Tests and benchmarks
- [ ] Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Put an x in the boxes that apply.
- [ ] Loaders
- [ ] Matchers
- [x] Track Errors
- [x] Metrics
- [ ] Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [x] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [x] I have updated the general documentation including Metric descriptions and example notebooks if necessary.

# Further Comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...