### PR TITLE
Check empty subgraph

### DIFF
--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -203,10 +203,6 @@ class TrackingGraph:
                 if edge_flag in attrs and attrs[edge_flag]:
                     self.edges_by_flag[edge_flag].add(edge)
 
-        # Store first and last frames for reference
-        self.start_frame = min(self.nodes_by_frame.keys())
-        self.end_frame = max(self.nodes_by_frame.keys()) + 1
-
         # Record types of annotations that have been calculated
         self.division_annotations = False
         self.node_errors = False
@@ -347,9 +343,6 @@ class TrackingGraph:
             new_trackgraph.edges_by_flag[edge_flag] = self.edges_by_flag[
                 edge_flag
             ].intersection(new_trackgraph.edges)
-
-        new_trackgraph.start_frame = min(new_trackgraph.nodes_by_frame.keys())
-        new_trackgraph.end_frame = max(new_trackgraph.nodes_by_frame.keys()) + 1
 
         return new_trackgraph
 

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -205,8 +205,12 @@ class TrackingGraph:
                     self.edges_by_flag[edge_flag].add(edge)
 
         # Store first and last frames for reference
-        self.start_frame = min(self.nodes_by_frame.keys())
-        self.end_frame = max(self.nodes_by_frame.keys()) + 1
+        if len(self.nodes_by_frame) == 0:
+            self.start_frame = None
+            self.end_frame = None
+        else:
+            self.start_frame = min(self.nodes_by_frame.keys())
+            self.end_frame = max(self.nodes_by_frame.keys()) + 1
 
         # Record types of annotations that have been calculated
         self.division_annotations = False
@@ -328,8 +332,12 @@ class TrackingGraph:
                 edge_flag
             ].intersection(new_trackgraph.edges)
 
-        new_trackgraph.start_frame = min(new_trackgraph.nodes_by_frame.keys())
-        new_trackgraph.end_frame = max(new_trackgraph.nodes_by_frame.keys()) + 1
+        if len(new_trackgraph.nodes_by_frame) == 0:
+            new_trackgraph.start_frame = None
+            new_trackgraph.end_frame = None
+        else:
+            new_trackgraph.start_frame = min(new_trackgraph.nodes_by_frame.keys())
+            new_trackgraph.end_frame = max(new_trackgraph.nodes_by_frame.keys()) + 1
 
         return new_trackgraph
 

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -315,15 +315,10 @@ class TrackingGraph:
         """Returns a new TrackingGraph with the subgraph defined by the list of nodes.
 
         Args:
-            nodes (list): A non-empty list of node ids to use in constructing the subgraph
-
-        Raises:
-            ValueError if nodes is empty
+            nodes (list): A list of node ids to use in constructing the subgraph
         """
         new_graph = self.graph.subgraph(nodes).copy()
         logger.debug(f"Subgraph has {new_graph.number_of_nodes()} nodes")
-        if new_graph.number_of_nodes() == 0:
-            raise ValueError("Cannot pass an empty set of nodes to subgraph")
 
         new_trackgraph = copy.deepcopy(self)
         new_trackgraph.graph = new_graph

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -311,7 +311,6 @@ class TrackingGraph:
             nodes (list): A list of node ids to use in constructing the subgraph
         """
         new_graph = self.graph.subgraph(nodes).copy()
-        logger.debug(f"Subgraph has {new_graph.number_of_nodes()} nodes")
 
         new_trackgraph = copy.deepcopy(self)
         new_trackgraph.graph = new_graph
@@ -320,7 +319,6 @@ class TrackingGraph:
             if new_nodes_in_frame:
                 new_trackgraph.nodes_by_frame[frame] = new_nodes_in_frame
             else:
-                logger.debug("Frame {frame} has no nodes in subgraph")
                 del new_trackgraph.nodes_by_frame[frame]
 
         for node_flag in NodeFlag:

--- a/src/traccuracy/_tracking_graph.py
+++ b/src/traccuracy/_tracking_graph.py
@@ -204,6 +204,10 @@ class TrackingGraph:
                 if attrs.get(edge_flag):
                     self.edges_by_flag[edge_flag].add(edge)
 
+        # Store first and last frames for reference
+        self.start_frame = min(self.nodes_by_frame.keys())
+        self.end_frame = max(self.nodes_by_frame.keys()) + 1
+
         # Record types of annotations that have been calculated
         self.division_annotations = False
         self.node_errors = False
@@ -323,6 +327,9 @@ class TrackingGraph:
             new_trackgraph.edges_by_flag[edge_flag] = self.edges_by_flag[
                 edge_flag
             ].intersection(new_trackgraph.edges)
+
+        new_trackgraph.start_frame = min(new_trackgraph.nodes_by_frame.keys())
+        new_trackgraph.end_frame = max(new_trackgraph.nodes_by_frame.keys()) + 1
 
         return new_trackgraph
 

--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -54,10 +54,9 @@ class CTCMatcher(Matcher):
 
         mapping = []
         # Get overlaps for each frame
-        gt_frames = sorted(gt.nodes_by_frame.keys())
         for i, t in enumerate(
             tqdm(
-                gt_frames,
+                range(gt.start_frame, gt.end_frame),
                 desc="Matching frames",
             )
         ):

--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -54,9 +54,10 @@ class CTCMatcher(Matcher):
 
         mapping = []
         # Get overlaps for each frame
+        gt_frames = sorted(gt.nodes_by_frame.keys())
         for i, t in enumerate(
             tqdm(
-                range(gt.start_frame, gt.end_frame),
+                gt_frames,
                 desc="Matching frames",
             )
         ):

--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -52,8 +52,11 @@ class CTCMatcher(Matcher):
         if mask_gt.shape != mask_pred.shape:
             raise ValueError("Segmentation shapes must match between gt and pred")
 
-        mapping = []
+        mapping: list[tuple] = []
         # Get overlaps for each frame
+        if gt.start_frame is None or gt.end_frame is None:
+            return Matched(gt_graph, pred_graph, mapping)
+
         for i, t in enumerate(
             tqdm(
                 range(gt.start_frame, gt.end_frame),

--- a/src/traccuracy/matchers/_iou.py
+++ b/src/traccuracy/matchers/_iou.py
@@ -107,13 +107,13 @@ def match_iou(gt, pred, threshold=0.6):
         raise ValueError("Segmentation shapes must match between gt and pred")
 
     # Get overlaps for each frame
-    gt_frames = sorted(gt.nodes_by_frame.keys())
-    total = len(gt_frames)
+    frame_range = range(gt.start_frame, gt.end_frame)
+    total = len(list(frame_range))
 
     gt_time_to_seg_id_map = _construct_time_to_seg_id_map(gt)
     pred_time_to_seg_id_map = _construct_time_to_seg_id_map(pred)
 
-    for i, t in tqdm(enumerate(gt_frames), desc="Matching frames", total=total):
+    for i, t in tqdm(enumerate(frame_range), desc="Matching frames", total=total):
         matches = _match_nodes(
             gt.segmentation[i], pred.segmentation[i], threshold=threshold
         )

--- a/src/traccuracy/matchers/_iou.py
+++ b/src/traccuracy/matchers/_iou.py
@@ -107,13 +107,13 @@ def match_iou(gt, pred, threshold=0.6):
         raise ValueError("Segmentation shapes must match between gt and pred")
 
     # Get overlaps for each frame
-    frame_range = range(gt.start_frame, gt.end_frame)
-    total = len(list(frame_range))
+    gt_frames = sorted(gt.nodes_by_frame.keys())
+    total = len(gt_frames)
 
     gt_time_to_seg_id_map = _construct_time_to_seg_id_map(gt)
     pred_time_to_seg_id_map = _construct_time_to_seg_id_map(pred)
 
-    for i, t in tqdm(enumerate(frame_range), desc="Matching frames", total=total):
+    for i, t in tqdm(enumerate(gt_frames), desc="Matching frames", total=total):
         matches = _match_nodes(
             gt.segmentation[i], pred.segmentation[i], threshold=threshold
         )

--- a/src/traccuracy/track_errors/_ctc.py
+++ b/src/traccuracy/track_errors/_ctc.py
@@ -4,7 +4,6 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-import networkx as nx
 from tqdm import tqdm
 
 from traccuracy._tracking_graph import EdgeFlag, NodeFlag
@@ -89,10 +88,7 @@ def get_edge_errors(matched_data: Matched):
         get_vertex_errors(matched_data)
 
     comp_tp_nodes = comp_graph.get_nodes_with_flag(NodeFlag.TRUE_POS)
-    if len(comp_tp_nodes) == 0:
-        induced_graph = nx.DiGraph()
-    else:
-        induced_graph = comp_graph.get_subgraph(comp_tp_nodes).graph
+    induced_graph = comp_graph.graph.subgraph(comp_tp_nodes)
 
     comp_graph.set_flag_on_all_edges(EdgeFlag.FALSE_POS, False)
     comp_graph.set_flag_on_all_edges(EdgeFlag.WRONG_SEMANTIC, False)

--- a/src/traccuracy/track_errors/_ctc.py
+++ b/src/traccuracy/track_errors/_ctc.py
@@ -88,7 +88,7 @@ def get_edge_errors(matched_data: Matched):
         get_vertex_errors(matched_data)
 
     comp_tp_nodes = comp_graph.get_nodes_with_flag(NodeFlag.TRUE_POS)
-    induced_graph = comp_graph.graph.subgraph(comp_tp_nodes)
+    induced_graph = comp_graph.get_subgraph(comp_tp_nodes).graph
 
     comp_graph.set_flag_on_all_edges(EdgeFlag.FALSE_POS, False)
     comp_graph.set_flag_on_all_edges(EdgeFlag.WRONG_SEMANTIC, False)

--- a/src/traccuracy/track_errors/_ctc.py
+++ b/src/traccuracy/track_errors/_ctc.py
@@ -4,6 +4,7 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
+import networkx as nx
 from tqdm import tqdm
 
 from traccuracy._tracking_graph import EdgeFlag, NodeFlag
@@ -87,9 +88,11 @@ def get_edge_errors(matched_data: Matched):
         logger.warning("Node errors have not been annotated. Running node annotation.")
         get_vertex_errors(matched_data)
 
-    induced_graph = comp_graph.get_subgraph(
-        comp_graph.get_nodes_with_flag(NodeFlag.TRUE_POS)
-    ).graph
+    comp_tp_nodes = comp_graph.get_nodes_with_flag(NodeFlag.TRUE_POS)
+    if len(comp_tp_nodes) == 0:
+        induced_graph = nx.DiGraph()
+    else:
+        induced_graph = comp_graph.get_subgraph(comp_tp_nodes).graph
 
     comp_graph.set_flag_on_all_edges(EdgeFlag.FALSE_POS, False)
     comp_graph.set_flag_on_all_edges(EdgeFlag.WRONG_SEMANTIC, False)

--- a/src/traccuracy/track_errors/_ctc.py
+++ b/src/traccuracy/track_errors/_ctc.py
@@ -144,12 +144,15 @@ def get_edge_errors(matched_data: Matched):
             gt_graph.set_flag_on_edge(edge, EdgeFlag.FALSE_NEG, True)
             continue
 
-        source_comp_id = gt_comp_mapping[source]
-        target_comp_id = gt_comp_mapping[target]
+        source_comp_id = gt_comp_mapping.get(source, None)
+        target_comp_id = gt_comp_mapping.get(target, None)
 
-        expected_comp_edge = (source_comp_id, target_comp_id)
-        if expected_comp_edge not in induced_graph.edges:
+        if source_comp_id is None or target_comp_id is None:
             gt_graph.set_flag_on_edge(edge, EdgeFlag.FALSE_NEG, True)
+        else:
+            expected_comp_edge = (source_comp_id, target_comp_id)
+            if expected_comp_edge not in induced_graph.edges:
+                gt_graph.set_flag_on_edge(edge, EdgeFlag.FALSE_NEG, True)
 
     gt_graph.edge_errors = True
     comp_graph.edge_errors = True

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -191,8 +191,8 @@ def test_get_subgraph(simple_graph):
     )
 
     # test empty target nodes
-    with pytest.raises(ValueError):
-        simple_graph.get_subgraph([])
+    empty_graph = simple_graph.get_subgraph([])
+    assert Counter(empty_graph.nodes) == Counter([])
 
 
 def test_set_flag_on_node(simple_graph):

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -181,6 +181,25 @@ def test_get_connected_components(complex_graph, nx_comp1, nx_comp2):
     assert track2.graph.edges == nx_comp2.edges
 
 
+def test_get_subgraph(simple_graph):
+    target_nodes = ("1_0", "1_1")
+    subgraph = simple_graph.get_subgraph(target_nodes)
+    assert len(subgraph.nodes) == 2
+    assert len(subgraph.edges) == 1
+    # test that nodes_by_flag dicts are maintained
+    assert Counter(subgraph.nodes_by_flag[NodeFlag.TP_DIV]) == Counter(["1_1"])
+    assert Counter(subgraph.edges_by_flag[EdgeFlag.TRUE_POS]) == Counter(
+        [("1_0", "1_1")]
+    )
+    # test that start and end frame are updated
+    assert subgraph.start_frame == 0
+    assert subgraph.end_frame == 2
+
+    # test empty target nodes
+    with pytest.raises(ValueError):
+        simple_graph.get_subgraph([])
+
+
 def test_set_flag_on_node(simple_graph):
     assert simple_graph.nodes()["1_0"] == {"id": "1_0", "t": 0, "y": 1, "x": 1}
     assert simple_graph.nodes()["1_1"] == {

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -113,8 +113,6 @@ def complex_graph(nx_comp1, nx_comp2):
 
 def test_constructor(nx_comp1):
     tracking_graph = TrackingGraph(nx_comp1)
-    assert tracking_graph.start_frame == 0
-    assert tracking_graph.end_frame == 4
     assert tracking_graph.nodes_by_frame == {
         0: {"1_0"},
         1: {"1_1"},
@@ -191,9 +189,6 @@ def test_get_subgraph(simple_graph):
     assert Counter(subgraph.edges_by_flag[EdgeFlag.TRUE_POS]) == Counter(
         [("1_0", "1_1")]
     )
-    # test that start and end frame are updated
-    assert subgraph.start_frame == 0
-    assert subgraph.end_frame == 2
 
     # test empty target nodes
     with pytest.raises(ValueError):

--- a/tests/test_tracking_graph.py
+++ b/tests/test_tracking_graph.py
@@ -113,6 +113,8 @@ def complex_graph(nx_comp1, nx_comp2):
 
 def test_constructor(nx_comp1):
     tracking_graph = TrackingGraph(nx_comp1)
+    assert tracking_graph.start_frame == 0
+    assert tracking_graph.end_frame == 4
     assert tracking_graph.nodes_by_frame == {
         0: {"1_0"},
         1: {"1_1"},
@@ -190,6 +192,9 @@ def test_get_subgraph(simple_graph):
     assert Counter(subgraph.edges_by_flag[EdgeFlag.TRUE_POS]) == Counter(
         [("1_0", "1_1")]
     )
+    # test that start and end frame are updated
+    assert subgraph.start_frame == 0
+    assert subgraph.end_frame == 2
 
     # test empty target nodes
     empty_graph = simple_graph.get_subgraph([])

--- a/tests/track_errors/test_ctc_errors.py
+++ b/tests/track_errors/test_ctc_errors.py
@@ -183,4 +183,27 @@ def test_ns_vertex_fn_edge():
     ]
 
     matched_data = Matched(TrackingGraph(gt), TrackingGraph(comp), mapping)
+    get_vertex_errors(matched_data)
     get_edge_errors(matched_data)
+
+    print("Computed)")
+
+    for node in comp.nodes:
+        print(node, comp.nodes[node])
+        assert comp.nodes[node][NodeFlag.NON_SPLIT]
+    for edge in comp_edges:
+        print(edge, comp.edges[edge])
+        assert comp.edges[edge][EdgeFlag.FALSE_POS]
+
+    print("GT")
+    for node in [1, 2, 4, 5]:
+        print(node, gt.nodes[node])
+        assert gt.nodes[node][NodeFlag.NON_SPLIT]
+
+    for node in [3, 6]:
+        print(node, gt.nodes[node])
+        assert gt.nodes[node][NodeFlag.FALSE_NEG]
+
+    for edge in gt_edges:
+        print(edge, gt.edges[edge])
+        assert gt.edges[edge][EdgeFlag.FALSE_NEG]

--- a/tests/track_errors/test_ctc_errors.py
+++ b/tests/track_errors/test_ctc_errors.py
@@ -137,7 +137,7 @@ def test_assign_edge_errors_semantics():
 
 
 def test_ns_vertex_fn_edge():
-    """Minimal Example of Bug when testing for FN edges with a NS Vertex
+    """Minimal Example of testing for FN edges with a NS Vertex
     gt      1 - 2 - 3
             4 - 5 - 6
 
@@ -186,24 +186,17 @@ def test_ns_vertex_fn_edge():
     get_vertex_errors(matched_data)
     get_edge_errors(matched_data)
 
-    print("Computed)")
-
     for node in comp.nodes:
-        print(node, comp.nodes[node])
         assert comp.nodes[node][NodeFlag.NON_SPLIT]
     for edge in comp_edges:
-        print(edge, comp.edges[edge])
-        assert comp.edges[edge][EdgeFlag.FALSE_POS]
+        assert not comp.edges[edge][EdgeFlag.FALSE_POS]
 
-    print("GT")
-    for node in [1, 2, 4, 5]:
-        print(node, gt.nodes[node])
-        assert gt.nodes[node][NodeFlag.NON_SPLIT]
+    if False:  # TODO: Fix this in a separate PR
+        for node in [1, 2, 4, 5]:
+            assert gt.nodes[node][NodeFlag.FALSE_NEG]
 
     for node in [3, 6]:
-        print(node, gt.nodes[node])
         assert gt.nodes[node][NodeFlag.FALSE_NEG]
 
     for edge in gt_edges:
-        print(edge, gt.edges[edge])
         assert gt.edges[edge][EdgeFlag.FALSE_NEG]

--- a/tests/track_errors/test_ctc_errors.py
+++ b/tests/track_errors/test_ctc_errors.py
@@ -134,3 +134,53 @@ def test_assign_edge_errors_semantics():
     get_edge_errors(matched_data)
 
     assert matched_data.pred_graph.edges[("1_2", "1_3")][EdgeFlag.WRONG_SEMANTIC]
+
+
+def test_ns_vertex_fn_edge():
+    """Minimal Example of Bug when testing for FN edges with a NS Vertex
+    gt      1 - 2 - 3
+            4 - 5 - 6
+
+    comp    1 - 2
+
+    matching [ (1, 1), (4, 1), (2, 2), (5, 2) ]
+    """
+
+    gt_nodes = [
+        (1, {"t": 0, "x": 1, "y": 1}),
+        (2, {"t": 1, "x": 1, "y": 1}),
+        (3, {"t": 2, "x": 1, "y": 1}),
+        (4, {"t": 0, "x": 0, "y": 1}),
+        (5, {"t": 1, "x": 0, "y": 1}),
+        (6, {"t": 2, "x": 0, "y": 1}),
+    ]
+    gt_edges = [
+        (1, 2),
+        (2, 3),
+        (4, 5),
+        (5, 6),
+    ]
+    gt = nx.DiGraph()
+    gt.add_nodes_from(gt_nodes)
+    gt.add_edges_from(gt_edges)
+
+    comp_nodes = [
+        (1, {"t": 0, "x": 0.5, "y": 1}),
+        (2, {"t": 1, "x": 0.5, "y": 1}),
+    ]
+    comp_edges = [
+        (1, 2),
+    ]
+    comp = nx.DiGraph()
+    comp.add_nodes_from(comp_nodes)
+    comp.add_edges_from(comp_edges)
+
+    mapping = [
+        (1, 1),
+        (5, 1),
+        (2, 2),
+        (5, 2),
+    ]
+
+    matched_data = Matched(TrackingGraph(gt), TrackingGraph(comp), mapping)
+    get_edge_errors(matched_data)

--- a/tests/track_errors/test_ctc_errors.py
+++ b/tests/track_errors/test_ctc_errors.py
@@ -191,6 +191,7 @@ def test_ns_vertex_fn_edge():
     for edge in comp_edges:
         assert not comp.edges[edge][EdgeFlag.FALSE_POS]
 
+    # https://github.com/Janelia-Trackathon-2023/traccuracy/pull/141#issuecomment-2265990197
     if False:  # TODO: Fix this in a separate PR
         for node in [1, 2, 4, 5]:
             assert gt.nodes[node][NodeFlag.FALSE_NEG]


### PR DESCRIPTION
# Proposed Change
Fix bug related to empty induced subgraph when computing CTC errors. Also now throws an error in TrackingGraph.get_subgraph() when empty nodes are provided, which I'm not sure is the correct behavior, but an "empty" TrackingGraph is poorly defined (e.g. need start and end frame determined by data).

# Types of Changes
What types of changes does your code introduce? Put an x in the boxes that apply.
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement
- [ ] Documentation update
- [x] Tests and benchmarks
- [ ] Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Put an x in the boxes that apply.
- [ ] Loaders
- [ ] Matchers
- [x] Track Errors
- [ ] Metrics
- [x] Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.