### PR TITLE
Speed up CTCMatcher

### DIFF
--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import networkx as nx
 import numpy as np
 from tqdm import tqdm
 
@@ -66,21 +65,17 @@ class CTCMatcher(Matcher):
             pred_frame_nodes = pred.nodes_by_frame[t]
 
             # get the labels for this frame
-            gt_labels = dict(
-                filter(
-                    lambda item: item[0] in gt_frame_nodes,
-                    nx.get_node_attributes(G_gt.graph, gt_label_key).items(),
-                )
-            )
-            gt_label_to_id = {v: k for k, v in gt_labels.items()}
+            gt_label_to_id = {
+                G_gt.graph.nodes[node][gt_label_key]: node
+                for node in gt_frame_nodes
+                if gt_label_key in G_gt.graph.nodes[node]
+            }
 
-            pred_labels = dict(
-                filter(
-                    lambda item: item[0] in pred_frame_nodes,
-                    nx.get_node_attributes(G_pred.graph, pred_label_key).items(),
-                )
-            )
-            pred_label_to_id = {v: k for k, v in pred_labels.items()}
+            pred_label_to_id = {
+                G_pred.graph.nodes[node][pred_label_key]: node
+                for node in pred_frame_nodes
+                if pred_label_key in G_pred.graph.nodes[node]
+            }
 
             (
                 overlapping_gt_labels,


### PR DESCRIPTION
# Proposed Change
For obtaining single-frame segmentation-label to node id mappings, for larger graphs it is faster to only get the node attribute dictionaries for the nodes present in the needed frame.

For example for PhC-C2DL-PSC, this leads to a ~3x speedup for matching.


# Types of Changes
What types of changes does your code introduce? Put an x in the boxes that apply.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature or enhancement
- [ ] Documentation update
- [ ] Tests and benchmarks
- [ ] Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Put an x in the boxes that apply.
- [ ] Loaders
- [x] Matchers
- [ ] Track Errors
- [ ] Metrics
- [ ] Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.