### PR TITLE
Add iou matcher option to use linear assignment to get one-to-one matching

### DIFF
--- a/src/traccuracy/matchers/_iou.py
+++ b/src/traccuracy/matchers/_iou.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Hashable
 
 import numpy as np
+from scipy.optimize import linear_sum_assignment
 from tqdm import tqdm
 
 from traccuracy._tracking_graph import TrackingGraph
@@ -11,7 +12,7 @@ from ._base import Matched, Matcher
 from ._compute_overlap import get_labels_with_overlap
 
 
-def _match_nodes(gt, res, threshold=1):
+def _match_nodes(gt, res, threshold=0.5, one_to_one=False, unmapped_cost=4):
     """Identify overlapping objects according to IoU and a threshold for minimum overlap.
 
     QUESTION: Does this rely on sequential segmentation labels
@@ -22,6 +23,11 @@ def _match_nodes(gt, res, threshold=1):
         threshold (optional, float): threshold value for IoU to count as same cell. Default 1.
             If segmentations are identical, 1 works well.
             For imperfect segmentations try 0.6-0.8 to get better matching
+        one_to_one (optional, bool): If True, forces the mapping to be one-to-one by running
+            linear assignment on the thresholded iou array. Default False.
+        unmapped_cost (float, optional): Cost of an unassigned cell.
+            Lower values leads to more unassigned cells. Defaults to 4.
+
     Returns:
         gtcells (np arr): Array of overlapping ids in the gt frame.
         rescells (np arr): Array of overlapping ids in the res frame.
@@ -37,7 +43,10 @@ def _match_nodes(gt, res, threshold=1):
         union = np.logical_or(gt == iou_gt_idx, res == iou_res_idx)
         iou[iou_gt_idx, iou_res_idx] = intersection.sum() / union.sum()
 
-    pairs = np.where(iou >= threshold)
+    if one_to_one:
+        pairs = _one_to_one_assignment(iou, unmapped_cost=unmapped_cost)
+    else:
+        pairs = np.where(iou >= threshold)
 
     # Catch the case where there are no overlaps
     if len(pairs) < 2:
@@ -46,6 +55,52 @@ def _match_nodes(gt, res, threshold=1):
         gtcells, rescells = pairs[0], pairs[1]
 
     return gtcells, rescells
+
+
+def _one_to_one_assignment(iou, unmapped_cost=4):
+    """Perform linear assignment on the iou matrix to create a one-to-one
+    mapping
+
+    Args:
+        iou (np.array): Array containing thresholded iou values
+        unmapped_cost (float, optional): Cost of an unassigned cell.
+            Lower values leads to more unassigned cells. Defaults to 4.
+
+    Returns:
+        tuple: Tuple of two arrays, one for indices of each axis
+    """
+    # Determine number of objects in zeroth and first axis
+    # Exclude the background which is currently included in iou matrix
+    n0 = iou.shape[0] - 1
+    n1 = iou.shape[1] - 1
+    n_obj = n0 + n1
+    matrix = np.ones((n_obj, n_obj))
+
+    # Assign 1 - iou to top left and bottom right
+    cost = 1 - iou[1:, 1:]
+    matrix[:n0, :n1] = cost
+    matrix[n_obj - n1 :, n_obj - n0 :] = cost.T
+
+    # Calculate diagonal corners
+    bl = unmapped_cost * np.eye(n1) + np.ones((n1, n1)) - np.eye(n1)
+    tr = unmapped_cost * np.eye(n0) + np.ones((n0, n0)) - np.eye(n0)
+
+    # Assign diagonals to cm
+    matrix[n_obj - n1 :, :n1] = bl
+    matrix[:n0, n_obj - n0 :] = tr
+
+    results = linear_sum_assignment(matrix)
+
+    # Map results back to cost matrix
+    assignment_matrix = np.zeros_like(matrix)
+    assignment_matrix[results] = 1
+
+    # Pull out only the direct matches from the top left corner
+    matches = np.nonzero(assignment_matrix[:n0, :n1])
+
+    # Add 1 to all indices to correct for removing the background previously
+    matches = (matches[0] + 1, matches[1] + 1)
+    return matches
 
 
 def _construct_time_to_seg_id_map(
@@ -77,7 +132,7 @@ def _construct_time_to_seg_id_map(
     return time_to_seg_id_map
 
 
-def match_iou(gt, pred, threshold=0.6):
+def match_iou(gt, pred, threshold=0.6, one_to_one=False, unmapped_cost=4):
     """Identifies pairs of cells between gt and pred that have iou > threshold
 
     This can return more than one match for any node
@@ -88,6 +143,10 @@ def match_iou(gt, pred, threshold=0.6):
         gt (traccuracy.TrackingGraph): Tracking data object containing graph and segmentations
         pred (traccuracy.TrackingGraph): Tracking data object containing graph and segmentations
         threshold (float, optional): Minimum IoU for matching cells. Defaults to 0.6.
+        one_to_one (optional, bool): If True, forces the mapping to be one-to-one by running
+            linear assignment on the thresholded iou array. Default False.
+        unmapped_cost (float, optional): Cost of an unassigned cell.
+            Lower values leads to more unassigned cells. Defaults to 4.
 
     Returns:
         list[(gt_node, pred_node)]: list of tuples where each tuple contains a gt node and pred node
@@ -115,7 +174,11 @@ def match_iou(gt, pred, threshold=0.6):
 
     for i, t in tqdm(enumerate(frame_range), desc="Matching frames", total=total):
         matches = _match_nodes(
-            gt.segmentation[i], pred.segmentation[i], threshold=threshold
+            gt.segmentation[i],
+            pred.segmentation[i],
+            threshold=threshold,
+            one_to_one=one_to_one,
+            unmapped_cost=unmapped_cost,
         )
         # Construct node id tuple for each match
         for gt_seg_id, pred_seg_id in zip(*matches):
@@ -133,10 +196,16 @@ class IOUMatcher(Matcher):
 
     Args:
         iou_threshold (float, optional): Minimum IoU value to assign a match. Defaults to 0.6.
+        one_to_one (optional, bool): If True, forces the mapping to be one-to-one by running
+            linear assignment on the thresholded iou array. Default False.
+        unmapped_cost (float, optional): Cost of an unassigned cell.
+            Lower values leads to more unassigned cells. Defaults to 4.
     """
 
-    def __init__(self, iou_threshold=0.6):
+    def __init__(self, iou_threshold=0.6, one_to_one=False, unmapped_cost=4):
         self.iou_threshold = iou_threshold
+        self.one_to_one = one_to_one
+        self.unmapped_cost = unmapped_cost
 
     def _compute_mapping(self, gt_graph: TrackingGraph, pred_graph: TrackingGraph):
         """Computes IOU mapping for a set of grpahs
@@ -157,6 +226,11 @@ class IOUMatcher(Matcher):
                 "Segmentation data must be provided for both gt and pred data"
             )
 
-        mapping = match_iou(gt_graph, pred_graph, threshold=self.iou_threshold)
+        mapping = match_iou(
+            gt_graph,
+            pred_graph,
+            threshold=self.iou_threshold,
+            one_to_one=self.one_to_one,
+        )
 
         return Matched(gt_graph, pred_graph, mapping)

--- a/src/traccuracy/matchers/_iou.py
+++ b/src/traccuracy/matchers/_iou.py
@@ -79,9 +79,12 @@ def _one_to_one_assignment(iou, unmapped_cost=4):
     matrix[:n0, :n1] = cost
     matrix[n_obj - n1 :, n_obj - n0 :] = cost.T
 
-    # Calculate diagonal corners
-    bl = unmapped_cost * np.eye(n1) + np.ones((n1, n1)) - np.eye(n1)
-    tr = unmapped_cost * np.eye(n0) + np.ones((n0, n0)) - np.eye(n0)
+    # Calculate unassigned corners, with base cost of 10*unmapped cost
+    # Diagonals are set to unmapped_cost
+    bl = np.full((n1, n1), unmapped_cost * 10)
+    np.fill_diagonal(bl, unmapped_cost)
+    tr = np.full((n0, n0), unmapped_cost * 10)
+    np.fill_diagonal(tr, unmapped_cost)
 
     # Assign diagonals to cm
     matrix[n_obj - n1 :, :n1] = bl

--- a/tests/matchers/test_iou.py
+++ b/tests/matchers/test_iou.py
@@ -60,7 +60,7 @@ def test__match_nodes():
     # Check for direct match
     assert (1, 3) in matches
     # Check that only one of the merge matches is present
-    assert (2, 4) in matches or (2, 5) in matches
+    assert ((2, 4) in matches) != ((2, 5) in matches)
 
 
 def test__construct_time_to_seg_id_map():

--- a/tests/matchers/test_iou.py
+++ b/tests/matchers/test_iou.py
@@ -12,6 +12,28 @@ from traccuracy.matchers._iou import (
 from tests.test_utils import get_annotated_image, get_movie_with_graph
 
 
+def get_two_to_one(w, h, imw, imh):
+    """Basic two cell merge/split
+
+    Mapping [(1,3), (2,4), (2,5)]
+
+    """
+    x = np.random.randint(2, imw - w * 2)
+    y = np.random.randint(2, imh - h * 2)
+
+    merge = np.zeros((imw, imh))
+    merge[0:2, 0:2] = 1
+    merge[x : x + w, y : y + h] = 2
+    merge[x + w : x + 2 * w, y : y + h] = 2
+
+    split = np.zeros((imw, imh))
+    split[0:2, 0:2] = 3
+    split[x : x + w, y : y + h] = 4
+    split[x + w : x + 2 * w, y : y + h] = 5
+
+    return merge.astype("int"), split.astype("int")
+
+
 def test__match_nodes():
     # creat dummy image to test against
     num_labels = 5
@@ -24,6 +46,23 @@ def test__match_nodes():
     # test different movies (no assertions about matching)
     y2 = get_annotated_image(img_size=256, num_labels=num_labels, seed=10)
     gtcells, rescells = _match_nodes(y1, y2)
+
+    # Test for merge without forcing one to one
+    im1, im2 = get_two_to_one(10, 10, 30, 30)
+    gtcells, rescells = _match_nodes(im1, im2, threshold=0.4)
+    for gt_cell, res_cell in zip(gtcells, rescells):
+        assert (int(gt_cell), int(res_cell)) in [(1, 3), (2, 4), (2, 5)]
+
+    # Test for merge and force one to one
+    gtcells, rescells = _match_nodes(
+        im1, im2, threshold=0.4, one_to_one=True, unmapped_cost=4
+    )
+    # Create match tuples
+    matches = list(zip(gtcells, rescells))
+    # Check for direct match
+    assert (1, 3) in matches
+    # Check that only one of the merge matches is present
+    assert (2, 4) in matches or (2, 5) in matches
 
 
 def test__construct_time_to_seg_id_map():

--- a/tests/matchers/test_iou.py
+++ b/tests/matchers/test_iou.py
@@ -54,9 +54,7 @@ def test__match_nodes():
         assert (int(gt_cell), int(res_cell)) in [(1, 3), (2, 4), (2, 5)]
 
     # Test for merge and force one to one
-    gtcells, rescells = _match_nodes(
-        im1, im2, threshold=0.4, one_to_one=True, unmapped_cost=4
-    )
+    gtcells, rescells = _match_nodes(im1, im2, threshold=0.4, one_to_one=True)
     # Create match tuples
     matches = list(zip(gtcells, rescells))
     # Check for direct match


### PR DESCRIPTION
# Proposed Change
This PR adds an option to the `IOUMatcher` to force the mapping to be one-to-one using linear sum assignment. Enabling this option makes the `IOUMatcher` compatible with division metrics.

# Types of Changes
What types of changes does your code introduce? Put an x in the boxes that apply.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature or enhancement
- [ ] Documentation update
- [ ] Tests and benchmarks
- [ ] Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Put an x in the boxes that apply.
- [ ] Loaders
- [x] Matchers
- [ ] Track Errors
- [ ] Metrics
- [ ] Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [x] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [x] I have updated the general documentation including Metric descriptions and example notebooks if necessary.