### PR TITLE
Remove support for python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = ["wheel", "setuptools>=40.8.0", "setuptools_scm"]
 name = "traccuracy"
 description = "Utilities for computing common accuracy metrics on cell tracking challenge solutions with ground truth"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "BSD 3-Clause License" }
 authors = [
     { email = "draga.doncilapop1@monash.edu", name = "Draga Doncila Pop" },
@@ -21,7 +21,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
# Proposed Change
`traccuracy` is failing to install on Mac/python 3.8 because `imagecodecs` has dropped support for python 3.8. I suggest that we follow suite and stop supporting python 3.8. If there is a better/easier solution, I'm happy to adopt it.

# Types of Changes
What types of changes does your code introduce? Put an x in the boxes that apply.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature or enhancement
- [ ] Documentation update
- [ ] Tests and benchmarks
- [x] Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Put an x in the boxes that apply.
- [ ] Loaders
- [ ] Matchers
- [ ] Track Errors
- [ ] Metrics
- [ ] Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.