### PR TITLE
Speed up IoU Matcher

### DIFF
--- a/src/traccuracy/matchers/_ctc.py
+++ b/src/traccuracy/matchers/_ctc.py
@@ -84,7 +84,7 @@ class CTCMatcher(Matcher):
                 overlapping_gt_labels,
                 overlapping_pred_labels,
                 intersection,
-            ) = get_labels_with_overlap(gt_frame, pred_frame)
+            ) = get_labels_with_overlap(gt_frame, pred_frame, overlap="iogt")
 
             for i in range(len(overlapping_gt_labels)):
                 gt_label = overlapping_gt_labels[i]

--- a/src/traccuracy/matchers/_iou.py
+++ b/src/traccuracy/matchers/_iou.py
@@ -35,16 +35,16 @@ def _match_nodes(gt, res, threshold=0.5, one_to_one=False):
     # casting to int to avoid issue #152 (result is float with numpy<2, dtype=uint64)
     iou = np.zeros((int(np.max(gt) + 1), int(np.max(res) + 1)))
 
-    overlapping_gt_labels, overlapping_res_labels, _ = get_labels_with_overlap(gt, res)
+    overlapping_gt_labels, overlapping_res_labels, ious = get_labels_with_overlap(
+        gt, res, overlap="iou"
+    )
 
-    for index in range(len(overlapping_gt_labels)):
-        iou_gt_idx = overlapping_gt_labels[index]
-        iou_res_idx = overlapping_res_labels[index]
-        intersection = np.logical_and(gt == iou_gt_idx, res == iou_res_idx)
-        union = np.logical_or(gt == iou_gt_idx, res == iou_res_idx)
-        iou_value = intersection.sum() / union.sum()
-        if iou_value >= threshold:
-            iou[iou_gt_idx, iou_res_idx] = iou_value
+    # for index in range(len(overlapping_gt_labels)):
+    for gt_label, res_label, iou_val in zip(
+        overlapping_gt_labels, overlapping_res_labels, ious
+    ):
+        if iou_val >= threshold:
+            iou[gt_label, res_label] = iou_val
 
     if one_to_one:
         pairs = _one_to_one_assignment(iou)

--- a/tests/matchers/test_compute_overlap.py
+++ b/tests/matchers/test_compute_overlap.py
@@ -1,3 +1,4 @@
+import pytest
 from traccuracy.matchers._compute_overlap import (
     get_labels_with_overlap,
 )
@@ -5,19 +6,8 @@ from traccuracy.matchers._compute_overlap import (
 from tests.test_utils import get_annotated_image
 
 
-def test_get_labels_with_overlap():
-    """Get all labels IDs in gt_frame and res_frame whose bounding boxes
-    overlap.
-
-    Args:
-        gt_frame (np.ndarray): ground truth segmentation for a single frame
-        res_frame (np.ndarray): result segmentation for a given frame
-
-    Returns:
-        overlapping_gt_labels: List[int], labels of gt boxes that overlap with res boxes
-        overlapping_res_labels: List[int], labels of res boxes that overlap with gt boxes
-        intersections_over_gt: List[float], list of (intersection gt vs res) / (gt area)
-    """
+@pytest.mark.parametrize("overlap", ["iou", "iogt"])
+def test_get_labels_with_overlap(overlap):
     n_labels = 3
     image1 = get_annotated_image(
         img_size=256, num_labels=n_labels, sequential=True, seed=1
@@ -29,13 +19,19 @@ def test_get_labels_with_overlap():
         img_size=256, num_labels=0, sequential=True, seed=1
     )
 
-    perfect_gt, perfect_res, perfect_ious = get_labels_with_overlap(image1, image1)
+    perfect_gt, perfect_res, perfect_ious = get_labels_with_overlap(
+        image1, image1, overlap
+    )
     assert list(perfect_gt) == list(range(1, n_labels + 1))
     assert list(perfect_res) == list(range(1, n_labels + 1))
     assert list(perfect_ious) == [1.0] * n_labels
-    get_labels_with_overlap(image1, image2)
+
+    get_labels_with_overlap(image1, image2, overlap)
+
     # Test empty labels array
-    empty_gt, empty_res, empty_ious = get_labels_with_overlap(image1, empty_image)
+    empty_gt, empty_res, empty_ious = get_labels_with_overlap(
+        image1, empty_image, overlap
+    )
     assert empty_gt == []
     assert empty_res == []
     assert empty_ious == []


### PR DESCRIPTION
This commit brings the speed ups already in place in the CTC matcher to the IoU matcher. It calculates the IoU on local crops instead of full label images.

If you are implementing a new matcher or metric, please append this `&template=new_matcher_metric.md` to your url to load the correct template.

# Proposed Change
Briefly describe the contribution. If it resolves an issue or feature request, be sure to link to that issue.

# Types of Changes
What types of changes does your code introduce? Put an x in the boxes that apply.
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature or enhancement
- [ ] Documentation update
- [x] Tests and benchmarks
- [ ] Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Put an x in the boxes that apply.
- [ ] Loaders
- [x] Matchers
- [ ] Track Errors
- [ ] Metrics
- [ ] Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [x] I have updated the general documentation including Metric descriptions and example notebooks if necessary.

# Further Comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...