### PR TITLE
Reduce number of checkboxes in issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/features.md
+++ b/.github/ISSUE_TEMPLATE/features.md
@@ -13,18 +13,18 @@ Please describe the feature that you would like to see implemented in `traccurac
 
 # Topics
 
-What types of changes are you suggesting? Put an x in the boxes that apply.
-- [ ] New feature or enhancement
-- [ ] Documentation update
-- [ ] Tests and benchmarks
-- [ ] Maintenance (e.g. dependencies, CI, releases, etc.)
+What types of changes are you suggesting? Delete those that do not apply.
+- New feature or enhancement
+- Documentation update
+- Tests and benchmarks
+- Maintenance (e.g. dependencies, CI, releases, etc.)
 
-Which topics does your change affect? Put an x in the boxes that apply.
-- [ ] Loaders
-- [ ] Matchers
-- [ ] Track Errors
-- [ ] Metrics
-- [ ] Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)
+Which topics does your change affect? Delete those that do not apply.
+- Loaders
+- Matchers
+- Track Errors
+- Metrics
+- Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)
 
 # Priority
 - [ ] This is an essential feature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,19 +4,19 @@ If you are implementing a new matcher or metric, please append this `&template=n
 Briefly describe the contribution. If it resolves an issue or feature request, be sure to link to that issue.
 
 # Types of Changes
-What types of changes does your code introduce? Put an x in the boxes that apply.
-- [ ] Bugfix (non-breaking change which fixes an issue)
-- [ ] New feature or enhancement
-- [ ] Documentation update
-- [ ] Tests and benchmarks
-- [ ] Maintenance (e.g. dependencies, CI, releases, etc.)
+What types of changes does your code introduce? Delete those that do not apply.
+- Bugfix (non-breaking change which fixes an issue)
+- New feature or enhancement
+- Documentation update
+- Tests and benchmarks
+- Maintenance (e.g. dependencies, CI, releases, etc.)
 
-Which topics does your change affect? Put an x in the boxes that apply.
-- [ ] Loaders
-- [ ] Matchers
-- [ ] Track Errors
-- [ ] Metrics
-- [ ] Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)
+Which topics does your change affect? Delete those that do not apply.
+- Loaders
+- Matchers
+- Track Errors
+- Metrics
+- Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)
 
 # Checklist
 Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.


### PR DESCRIPTION
This PR gets rid of unnecessary check boxes in our PR and issue templates. Now we prompt to delete the items in the list that don't apply.