### PR TITLE
Metrics validate that the matcher is supported

### DIFF
--- a/src/traccuracy/metrics/_base.py
+++ b/src/traccuracy/metrics/_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from importlib.metadata import version
 from typing import TYPE_CHECKING
+import warnings
 
 if TYPE_CHECKING:
     from traccuracy.matchers._base import Matched
@@ -15,11 +16,12 @@ class Metric(ABC):
     Kwargs should be specified in the constructor
     """
 
-    # Mapping criteria
-    needs_one_to_one = False
-    supports_one_to_many = False
-    supports_many_to_one = False
-    supports_many_to_many = False
+    @abstractmethod
+    def _validate_matcher(self, matched: Matched) -> bool:
+        """Verifies that the matched meets the assumptions of the metric
+        Returns True if matcher is valid and False if matcher is not valid"""
+
+        raise NotImplementedError
 
     @abstractmethod
     def _compute(self, matched: Matched) -> dict:
@@ -36,7 +38,7 @@ class Metric(ABC):
         """
         raise NotImplementedError
 
-    def compute(self, matched: Matched) -> Results:
+    def compute(self, matched: Matched, override_matcher: bool = False) -> Results:
         """The compute methods of Metric objects returns a Results object populated with results
         and associated metadata
 
@@ -46,6 +48,15 @@ class Metric(ABC):
         Returns:
             Results: Object containing metric results and associated pipeline metadata
         """
+        if override_matcher:
+            warnings.warn("Overriding matcher/metric validation may result in "
+                         "unpredictable/incorrect metric results")
+        
+        valid_matcher = self._validate_matcher(matched)
+        if not valid_matcher:
+            raise TypeError(
+                "The matched data uses a matcher that does not meet the requirements "
+                "of the metric. Check the documentation for the metric for more information.")
 
         res_dict = self._compute(matched)
 

--- a/src/traccuracy/metrics/_ctc.py
+++ b/src/traccuracy/metrics/_ctc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from traccuracy._tracking_graph import EdgeFlag, NodeFlag
+from traccuracy.matchers._base import Matched
 from traccuracy.track_errors._ctc import evaluate_ctc_events
 
 from ._base import Metric
@@ -12,7 +13,6 @@ if TYPE_CHECKING:
 
 
 class AOGMMetrics(Metric):
-    supports_many_to_one = True
 
     def __init__(
         self,
@@ -33,6 +33,18 @@ class AOGMMetrics(Metric):
             "fn": edge_fn_weight,
             "ws": edge_ws_weight,
         }
+
+    def _validate_matcher(self, matched: Matched) -> bool:
+        valid_matchers = {
+            "IOUMatcher",
+            "CTCMatcher"
+        }
+        name = matched.matcher_info["name"]
+
+        if name in valid_matchers:
+            return True
+        else:
+            return False
 
     def _compute(self, data: Matched):
         evaluate_ctc_events(data)

--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from traccuracy._tracking_graph import NodeFlag
+from traccuracy.matchers._base import Matched
 from traccuracy.track_errors.divisions import _evaluate_division_events
 
 from ._base import Metric
@@ -63,10 +64,19 @@ class DivisionMetrics(Metric):
             buffer between 0 and max_frame_buffer
     """
 
-    needs_one_to_one = True
-
     def __init__(self, max_frame_buffer=0):
         self.frame_buffer = max_frame_buffer
+
+    def _validate_matcher(self, matched: Matched) -> bool:
+        "Matcher must be one to one"
+        name = matched.matcher_info["name"]
+        
+        if name == "IOUMatcher":
+            flag = matched.matcher_info["one_to_one"]
+            if flag:
+                return True
+        
+        return False
 
     def _compute(self, data: Matched):
         """Runs `_evaluate_division_events` and calculates summary metrics for each frame buffer

--- a/src/traccuracy/metrics/_track_overlap.py
+++ b/src/traccuracy/metrics/_track_overlap.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from itertools import groupby, product
 from typing import TYPE_CHECKING, Any
 
+from traccuracy.matchers._base import Matched
+
 from ._base import Metric
 
 if TYPE_CHECKING:
@@ -57,10 +59,20 @@ class TrackOverlapMetrics(Metric):
 
     """
 
-    supports_many_to_one = True
-
     def __init__(self, include_division_edges: bool = True):
         self.include_division_edges = include_division_edges
+
+    def _validate_matcher(self, matched: Matched) -> bool:
+        valid_matchers = {
+            "IOUMatcher",
+            "CTCMatcher"
+        }
+        name = matched.matcher_info["name"]
+
+        if name in valid_matchers:
+            return True
+        else:
+            return False
 
     def _compute(self, matched: Matched) -> dict:
         gt_tracklets = matched.gt_graph.get_tracklets(

--- a/tests/metrics/test_divisions.py
+++ b/tests/metrics/test_divisions.py
@@ -36,17 +36,13 @@ def pred_hela():
     )
 
 
-def test_ctc_div_metrics(gt_hela, pred_hela):
-    ctc_matched = CTCMatcher().compute_mapping(gt_hela, pred_hela)
-    div_results = DivisionMetrics().compute(ctc_matched)
-
-    assert div_results.results["Frame Buffer 0"]["False Negative Divisions"] == 18
-    assert div_results.results["Frame Buffer 0"]["False Positive Divisions"] == 30
-    assert div_results.results["Frame Buffer 0"]["True Positive Divisions"] == 76
-
-
 def test_iou_div_metrics(gt_hela, pred_hela):
+    # Fail validation if one-to-one not enabled
     iou_matched = IOUMatcher(iou_threshold=0.1).compute_mapping(gt_hela, pred_hela)
+    with pytest.raises(TypeError):
+        div_results = DivisionMetrics().compute(iou_matched)
+
+    iou_matched = IOUMatcher(iou_threshold=0.1, one_to_one=True).compute_mapping(gt_hela, pred_hela)
     div_results = DivisionMetrics().compute(iou_matched)
 
     assert div_results.results["Frame Buffer 0"]["False Negative Divisions"] == 25

--- a/tests/test_run_metrics.py
+++ b/tests/test_run_metrics.py
@@ -9,6 +9,9 @@ from tests.test_utils import get_movie_with_graph
 class DummyMetric(Metric):
     def _compute(self, matched):
         return {}
+    
+    def _validate_matcher(self, matched):
+        return True
 
 
 class DummyMetricParam(Metric):
@@ -17,6 +20,9 @@ class DummyMetricParam(Metric):
 
     def _compute(self, matched):
         return {}
+    
+    def _validate_matcher(self, matched):
+        return True
 
 
 class DummyMatcher(Matcher):


### PR DESCRIPTION
Closes #83 

Ultimately we are embracing a very manual/hard-coded approach. Each metric has to implement its own `_validate_matcher` function that can check both the name of the matcher and any associated parameters that may be relevant for that metric. For example, `IOUMatcher` is only valid for division metrics if `one_to_one=True`. 

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- New feature or enhancement

Which topics does your change affect? Delete those that do not apply.
- Matchers
- Metrics

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the developer/contributing docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.