### PR TITLE
Bugfix: fix testing issue with GT nodes matched to NS nodes

### DIFF
--- a/tests/track_errors/test_ctc_errors.py
+++ b/tests/track_errors/test_ctc_errors.py
@@ -273,10 +273,8 @@ def test_ns_vertex_fn_edge():
     for edge in comp_edges:
         assert EdgeFlag.CTC_FALSE_POS not in comp.edges[edge]
 
-    # https://github.com/Janelia-Trackathon-2023/traccuracy/pull/141#issuecomment-2265990197
-    if False:  # TODO: Fix this in a separate PR
-        for node in [1, 2, 4, 5]:
-            assert gt.nodes[node][NodeFlag.CTC_FALSE_NEG]
+    for node in [1, 2, 4, 5]:
+        assert NodeFlag.CTC_FALSE_NEG not in gt.nodes[node]
 
     for node in [3, 6]:
         assert gt.nodes[node][NodeFlag.CTC_FALSE_NEG]


### PR DESCRIPTION
Fixes #191 

When I tried, I couldn't reproduce the original issue that led us to comment out that block in the test. All I actually did here was update the code to reflect that GT nodes matched to a NS node are not annotated with any error type including FN.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Bugfix (non-breaking change which fixes an issue)

Which topics does your change affect? Delete those that do not apply.
- Track Errors

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [x] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [x] I have updated the general documentation including Metric descriptions and example notebooks if necessary.