### PR TITLE
Make consistent behavior when denom is 0 and add docstrings

### DIFF
--- a/src/traccuracy/metrics/_ctc.py
+++ b/src/traccuracy/metrics/_ctc.py
@@ -117,9 +117,6 @@ class CTCMetrics(AOGMMetrics):
             n_nodes (int): The number of nodes in the ground truth graph
             n_edges (int): The number of edges in the ground truth graph
 
-        Raises:
-            RuntimeError: if the AOGM0 is 0
-
         Returns:
             float: the TRA score, computed with the CTC metric weights, or np.nan if
                 the AOGM_0 is 0

--- a/src/traccuracy/metrics/_ctc.py
+++ b/src/traccuracy/metrics/_ctc.py
@@ -109,19 +109,55 @@ class CTCMetrics(AOGMMetrics):
 
         return errors
 
-    def _get_tra(self, errors, n_nodes, n_edges):
+    def _get_tra(self, errors: dict[str, int], n_nodes: int, n_edges: int) -> float:
+        """Get the TRA score from the error counts and total number of gt nodes and edges
+
+        Args:
+            errors (dict[str, int]): A dictionary containing the AOGM
+            n_nodes (int): The number of nodes in the ground truth graph
+            n_edges (int): The number of edges in the ground truth graph
+
+        Raises:
+            RuntimeError: if the AOGM0 is 0
+
+        Returns:
+            float: the TRA score, computed with the CTC metric weights, or np.nan if
+                the AOGM_0 is 0
+        """
         aogm_0 = n_nodes * self.v_weights["fn"] + n_edges * self.e_weights["fn"]
         if aogm_0 == 0:
-            raise RuntimeError(
-                f"AOGM0 is 0 - cannot compute TRA from GT graph with {n_nodes} nodes and"
-                + f" {n_edges} edges with {self.v_weights['fn']} vertex FN weight and"
-                + f" {self.e_weights['fn']} edge FN weight"
+            warnings.warn(
+                UserWarning(
+                    f"AOGM0 is 0 - cannot compute TRA from GT graph with {n_nodes} nodes and"
+                    + f" {n_edges} edges with {self.v_weights['fn']} vertex FN weight and"
+                    + f" {self.e_weights['fn']} edge FN weight"
+                ),
+                stacklevel=1,
             )
+            return np.nan
         aogm = errors["AOGM"]
         tra = 1 - min(aogm, aogm_0) / aogm_0
         return tra
 
-    def _get_det(self, errors, n_nodes):
+    def _get_det(self, errors: dict[str, int], n_nodes: int) -> float:
+        """Get the DET score from the error counts and total number of gt nodes
+
+        Args:
+            errors (dict[str, int]): A dictionary containing the counts
+                of each type of node error (fp_nodes, fn_nodes, ns_nodes)
+            n_nodes (int): The number of nodes in the ground truth graph
+
+        Returns:
+            float: the DET score, computed with the CTC metric weights, or np.nan
+                if there are no nodes in the gt graph
+        """
+        if n_nodes == 0:
+            warnings.warn(
+                UserWarning("No nodes in the GT graph, cannot compute DET."),
+                stacklevel=1,
+            )
+            return np.nan
+
         aogmd_0 = n_nodes * self.v_weights["fn"]
         aogmd = get_weighted_vertex_error_sum(
             {
@@ -136,7 +172,18 @@ class CTCMetrics(AOGMMetrics):
         det = 1 - min(aogmd, aogmd_0) / aogmd_0
         return det
 
-    def _get_lnk(self, errors, n_edges):
+    def _get_lnk(self, errors: dict[str, int], n_edges: int):
+        """Get the DET score from the error counts and total number of gt edges
+
+        Args:
+            errors (dict[str, int]): A dictionary containing the counts
+                of each type of edge error (fp_edges, fn_edges, ws_edges)
+            n_edges (int): The number of edges in the ground truth graph
+
+        Returns:
+            float: the TRA score, computed with the CTC metric weights, or np.nan if
+                there are no edges in the GT graph
+        """
         if n_edges == 0:
             warnings.warn(
                 UserWarning("No edges in the GT graph, cannot compute LNK."),


### PR DESCRIPTION
@DragaDoncila I was going to just add docstrings and type annotations, and then I noticed that the behavior was inconsistent between the different metrics for what happens when the denomintor is 0.

In this PR I change them all to warn and return np.nan, whereas previously the TRA raised a RuntimeError, the LNK warned and returned np.nan, and the DET did not check. I don't think I have strong opinions about which of these options is better, other than that checking for a zero denominator is good, so this is just a suggestion of one possible solution.

I didn't fix the tests, since I wanted your opinion on what the "correct" solution is first. Feel free to just pull the bits of code you want and treat this as a review rather than a PR - I just already wrote the code so I figured I would provide it.