### PR TITLE
Add workflow for generating a test case coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup cml for better commenting
+        uses: iterative/setup-cml@v2
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -196,19 +199,10 @@ jobs:
       - name: Run coverage report
         run: python scripts/test_case_report.py
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        id: artifact-upload-step
-        with:
-          name: 'coverage-plot'
-          path: 'test-case-coverage.png'
-
-      - name: Comment with plot link for non-forks
-        uses: peter-evans/commit-comment@v3
-        if: github.event.pull_request.head.repo.fork == false
-        with:
-          body: |
-            ![](${{ steps.artifact-upload-step.outputs.artifact-url }})
+      - name: Generate comment
+        run: |
+          echo "![](./test-case-coverage.png)" > report.md
+          cml comment create --target=commit/HEAD report.md
 
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,9 +181,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup cml for better commenting
-        uses: iterative/setup-cml@v2
-
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -199,7 +196,12 @@ jobs:
       - name: Run coverage report
         run: python scripts/test_case_report.py
 
+      - name: Setup cml for better commenting
+        uses: iterative/setup-cml@v2
+
       - name: Generate comment
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         run: |
           echo "![](./test-case-coverage.png)" > report.md
           cml comment create --target=commit/HEAD report.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
         uses: peter-evans/commit-comment@v3
         with:
           body: |
-            ![coverage plot](https://github.com/Janelia-Trackathon-2023/traccuracy/blob/test-case-coverage-report/${{ steps.hash.outputs.commit }}.png)
+            ![coverage plot](https://github.com/Janelia-Trackathon-2023/traccuracy/blob/test-case-coverage-report/${{ steps.hash.outputs.commit }}.png?raw=True)
 
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,9 @@ jobs:
           python -m pip install -U pip
           python -m pip install -e .[covreport]
 
+      - name: Run coverage report
+        run: python scripts/test_case_report.py
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         id: artifact-upload-step

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
       - name: Run coverage report
         run: python scripts/test_case_report.py ${{ github.event.pull_request.head.sha }}
 
-      - name: Checkout png branch
+      - name: Checkout branch for stashing pngs
         uses: actions/checkout@v4
         with:
           ref: 'test-case-coverage-report'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,41 @@ jobs:
         with:
           body-path: report.md
 
+  test-case-coverage:
+    name: Test case coverage
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache-dependency-path: "pyproject.toml"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -e .[covreport]
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        id: artifact-upload-step
+        with:
+          name: 'coverage-plot'
+          path: 'test-case-coverage.png'
+
+      - name: Comment with plot link for non-forks
+        uses: peter-evans/commit-comment@v3
+        if: github.event.pull_request.head.repo.fork == false
+        with:
+          body: |
+            ![](${{ steps.artifact-upload-step.outputs.artifact-url }})
+
+
   deploy:
     name: Deploy
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,18 +193,20 @@ jobs:
           python -m pip install -U pip
           python -m pip install -e .[covreport]
 
-      - name: Run coverage report
-        run: python scripts/test_case_report.py ${{ github.event.pull_request.head.sha }}
+      - name: Run coverage report and stash png
+        run: |
+          python scripts/test_case_report.py ${{ github.event.pull_request.head.sha }}
 
-      - name: Checkout branch for stashing pngs
-        uses: actions/checkout@v4
-        with:
-          ref: 'test-case-coverage-report'
+      - name: Add, stash, switch branch
+        run: |
+          git add ${{ github.event.pull_request.head.sha }}.png
+          git stash
+          git checkout -t origin/test-case-coverage-report
 
       - name: Commit to branch
         uses: EndBug/add-and-commit@v9
         with:
-          add: ${{ github.event.pull_request.head.sha }}.png
+          add: "*.png"
 
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
         run: |
           echo "![](./test-case-coverage.png)" > report.md
-          cml comment create --target=commit/HEAD report.md
+          cml comment create --target=commit/${{ github.event.pull_request.head.sha }} report.md
 
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,11 @@ jobs:
           python -m pip install -U pip
           python -m pip install -e .[covreport]
 
-      - name: Run coverage report and stash png
+      - name: Store target commit hash
+        id: hash
+        run: echo "commit=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Run coverage report
         run: |
           python scripts/test_case_report.py ${{ github.event.pull_request.head.sha }}
 
@@ -209,6 +213,12 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: "*.png"
+
+      - name: Comment with image link
+        uses: peter-evans/commit-comment@v3
+        with:
+          body: |
+            ![coverage plot](https://github.com/Janelia-Trackathon-2023/traccuracy/blob/test-case-coverage-report/${{ steps.hash.outputs.commit }}.png)
 
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,8 @@ jobs:
         run: |
           git add ${{ github.event.pull_request.head.sha }}.png
           git stash
-          git checkout -t origin/test-case-coverage-report
+          git fetch
+          git checkout test-case-coverage-report
 
       - name: Commit to branch
         uses: EndBug/add-and-commit@v9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,17 +194,17 @@ jobs:
           python -m pip install -e .[covreport]
 
       - name: Run coverage report
-        run: python scripts/test_case_report.py
+        run: python scripts/test_case_report.py ${{ github.event.pull_request.head.sha }}
 
-      - name: Setup cml for better commenting
-        uses: iterative/setup-cml@v2
+      - name: Checkout png branch
+        uses: actions/checkout@v4
+        with:
+          ref: 'test-case-coverage-report'
 
-      - name: Generate comment
-        env:
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
-        run: |
-          echo "![](./test-case-coverage.png)" > report.md
-          cml comment create --target=commit/${{ github.event.pull_request.head.sha }} report.md
+      - name: Commit to branch
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: ${{ github.event.pull_request.head.sha }}.png
 
 
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
           git stash
           git fetch
           git checkout test-case-coverage-report
+          git stash pop
 
       - name: Commit to branch
         uses: EndBug/add-and-commit@v9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,10 @@ docs = [
     "jupyter-sphinx",
     "matplotlib"
 ]
+covreport = [
+    "traccuracy[test]",
+    "seaborn"
+]
 
 [project.urls]
 homepage = "https://github.com/Janelia-Trackathon-2023/traccuracy"

--- a/scripts/test_case_report.py
+++ b/scripts/test_case_report.py
@@ -176,7 +176,7 @@ def get_stats_df(target_key: str) -> pd.DataFrame:
     return df
 
 
-def plot_heatmap(df: pd.Dataframe, name: str, ax: Axes, groups: Dict[str, List[str]]):
+def plot_heatmap(df: pd.DataFrame, name: str, ax: Axes, groups: Dict[str, List[str]]):
     """Plot a heatmap where the functions specified in each group are separated by a blank row
 
     Any functions in df that are not included in groups are collected into a final "Ungrouped"

--- a/scripts/test_case_report.py
+++ b/scripts/test_case_report.py
@@ -1,6 +1,7 @@
 import glob
 import json
 import os
+import sys
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -88,6 +89,7 @@ def plot_heatmap(df, name, ax):
 
 
 if __name__ == "__main__":
+    output_name = sys.argv[1]
     param_sets = [("track_errors", "graphs"), ("matchers", "segs")]
 
     dfs, maxcols, maxrows = [], [], []
@@ -108,4 +110,4 @@ if __name__ == "__main__":
         plot_heatmap(df, name, ax)
     plt.tight_layout()
 
-    plt.savefig("test-case-coverage.png")
+    plt.savefig(f"{output_name}.png")

--- a/scripts/test_case_report.py
+++ b/scripts/test_case_report.py
@@ -1,0 +1,111 @@
+import glob
+import json
+import os
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import pytest
+import seaborn as sns
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SKIP_FILES = ["__", "base", "compute_overlap"]
+SKIP_FUNCTIONS = [
+    "basic_graph",
+    "get_division_graphs",
+    "basic_division",
+    "basic_division_t0",
+    "basic_division_t1",
+    "basic_division_t2",
+    "longer_division",
+    "",
+    "make_one_cell_2d",
+    "make_split_cell_2d",
+    "make_one_cell_3d",
+    "make_split_cell_3d",
+    "nodes_from_segmentation",
+    "sphere",
+]
+
+
+def run_coverage(test_target, ex_module):
+    test_dir = f"{ROOT_DIR}/tests/{test_target}"
+    files = os.listdir(test_dir)
+
+    for file in files:
+        # Skip init and any testing of base class
+        if not all(skip not in file for skip in SKIP_FILES):
+            continue
+        args = [
+            "--cov-report",
+            f"json:{test_target}-{os.path.basename(file)[:-3]}.json",
+            f"{test_dir}/{file}",
+            "--cov",
+            f"tests.examples.{ex_module}",
+        ]
+        print(args)
+        pytest.main(args)
+
+
+def get_stats_from_json(json_path):
+    with open(json_path) as f:
+        data = json.load(f)
+
+    target_file = next(iter(data["files"].keys()))
+    rows, stats = [], []
+    for fxn, d in data["files"][target_file]["functions"].items():
+        # Skip functions that are utilities
+        if fxn in SKIP_FUNCTIONS:
+            continue
+        rows.append(fxn)
+        stats.append(d["summary"]["percent_covered"])
+
+    colname = json_path.split("-")[-1][5:-5]
+
+    df = pd.DataFrame({"functions": rows, colname: stats})
+    df = df.set_index("functions")
+    return df
+
+
+def get_stats_df(target_key):
+    files = glob.glob(f"{target_key}-*.json")
+    dfs = []
+    for f in files:
+        dfs.append(get_stats_from_json(f))
+
+    # Concatenate to single dataframe
+    df = dfs[0].join(dfs[1])
+    for sdf in dfs[2:]:
+        df = df.join(sdf)
+
+    return df
+
+
+def plot_heatmap(df, name, ax):
+    sns.heatmap(df, linewidths=1, vmin=0, vmax=100, cmap="copper", ax=ax)
+    plt.xticks(rotation=45, ha="right")
+    ax.set_title(name)
+
+
+if __name__ == "__main__":
+    param_sets = [("track_errors", "graphs"), ("matchers", "segs")]
+
+    dfs, maxcols, maxrows = [], [], []
+    for name, target_mod in param_sets:
+        run_coverage(name, target_mod)
+        df = get_stats_df(name)
+        dfs.append(df)
+        maxcols.append(len(df.columns))
+        maxrows.append(len(df))
+
+    # Figsize params are really rough estimates to avoid hardcoded values
+    fig, axes = plt.subplots(
+        1,
+        len(param_sets),
+        figsize=(len(param_sets) * max(maxcols) * 2, max(maxrows) / 4),
+    )
+    for df, (name, _), ax in zip(dfs, param_sets, axes):
+        plot_heatmap(df, name, ax)
+    plt.tight_layout()
+
+    plt.savefig("test-case-coverage.png")


### PR DESCRIPTION
# Proposed Change
This PR introduces a new github action workflow that measures coverage of each error and matcher module against our standard test cases in `tests.examples`. The action generates a plot which is linked in a comment on the commit similar to the benchmarking action that runs for PRs.

The script is written such that if new modules are added to track_errors or matchers they should be incorporated automatically. The same is true of functions in the `tests.examples`. However, I can't promise that the sizing of the plot will work out automatically.

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Tests and benchmarks
- Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Delete those that do not apply.

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [x] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [x] I have updated the general documentation including Metric descriptions and example notebooks if necessary.