### PR TITLE
Implement a point to segmentation matcher

### DIFF
--- a/docs/source/matchers/matchers.md
+++ b/docs/source/matchers/matchers.md
@@ -19,6 +19,6 @@ they can produce, and a brief description of behavior and any hyperparameters.
 | Matcher | Matching Type(s) | Description |
 ----------|------------------|-------------
 | Point | `one-to-one`  |  Given a maximum distance threshold, the matcher will perform hungarian matching on the points in each frame of the ground truth and predicted graphs, minimizing the overall distance while never matching any points with distance greater than the threshold. |
-| Point to Seg| `one-to-one`, `many-to-one`, `one-to-many` | Given one dataset with segmentation data, this matcher will identify points that fall within a non-zero segmentation label. |
+| Point to Seg| `one-to-one`, `many-to-one`, `one-to-many` | Given one dataset with segmentation data, this matcher will match nodes from the points-only graph to nodes from the segmentation graph if and only if the point location is within the the segmentation label. |
 | IOU | `one-to-one`, `many-to-one`, `one-to-many` | Given a minimum overlap threshold, will match the segmentations in each frame of the ground truth and predicted tracks with  intersection-over-union greater than or equal to the given threshold. If the one-to-one flag is true, will produce a one-to-one matching by running linear assignment/hungarian matching on the thresholded iou array. |
 | CTC | `one-to-one`, `many-to-one` | A predicted node is matched to a reference node if the computed segmentation covers a majority of the reference segmentation. See https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0144959 for complete details. |

--- a/docs/source/matchers/matchers.md
+++ b/docs/source/matchers/matchers.md
@@ -19,5 +19,6 @@ they can produce, and a brief description of behavior and any hyperparameters.
 | Matcher | Matching Type(s) | Description |
 ----------|------------------|-------------
 | Point | `one-to-one`  |  Given a maximum distance threshold, the matcher will perform hungarian matching on the points in each frame of the ground truth and predicted graphs, minimizing the overall distance while never matching any points with distance greater than the threshold. |
+| Point to Seg| `one-to-one`, `many-to-one`, `one-to-many` | Given one dataset with segmentation data, this matcher will identify points that fall within a non-zero segmentation label. |
 | IOU | `one-to-one`, `many-to-one`, `one-to-many` | Given a minimum overlap threshold, will match the segmentations in each frame of the ground truth and predicted tracks with  intersection-over-union greater than or equal to the given threshold. If the one-to-one flag is true, will produce a one-to-one matching by running linear assignment/hungarian matching on the thresholded iou array. |
 | CTC | `one-to-one`, `many-to-one` | A predicted node is matched to a reference node if the computed segmentation covers a majority of the reference segmentation. See https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0144959 for complete details. |

--- a/src/traccuracy/loaders/_ctc.py
+++ b/src/traccuracy/loaders/_ctc.py
@@ -72,20 +72,27 @@ def _get_node_attributes(masks: np.ndarray) -> pd.DataFrame:
         pd.DataFrame: Dataframe with one detection per row. Columns
             segmentation_id, x, y, z, t
     """
+    if len(masks.shape) == 4:
+        columns = {
+            "label": "segmentation_id",
+            "centroid-2": "x",
+            "centroid-1": "y",
+            "centroid-0": "z",
+        }
+    else:
+        columns = {
+            "label": "segmentation_id",
+            "centroid-1": "x",
+            "centroid-0": "y",
+        }
+
     data_df = pd.concat(
         [
             _detections_from_image(masks, idx)
             for idx in tqdm(range(masks.shape[0]), desc="Computing node attributes")
         ],
     ).reset_index(drop=True)
-    data_df = data_df.rename(
-        columns={
-            "label": "segmentation_id",
-            "centroid-2": "z",
-            "centroid-1": "y",
-            "centroid-0": "x",
-        }
-    )
+    data_df = data_df.rename(columns=columns)
     data_df["segmentation_id"] = data_df["segmentation_id"].astype(int)
     data_df["t"] = data_df["t"].astype(int)
     return data_df

--- a/src/traccuracy/matchers/__init__.py
+++ b/src/traccuracy/matchers/__init__.py
@@ -31,11 +31,13 @@ from ._compute_overlap import get_labels_with_overlap
 from ._ctc import CTCMatcher
 from ._iou import IOUMatcher
 from ._point import PointMatcher
+from ._point_seg import PointSegMatcher
 
 __all__ = [
     "CTCMatcher",
     "IOUMatcher",
     "Matched",
     "PointMatcher",
+    "PointSegMatcher",
     "get_labels_with_overlap",
 ]

--- a/src/traccuracy/matchers/_point_seg.py
+++ b/src/traccuracy/matchers/_point_seg.py
@@ -26,7 +26,7 @@ class PointSegMatcher(Matcher):
     ) -> list[tuple[Any, Any]]:
         # Identify which data has segmentations
         # s data has seg, p data has points
-        # If both have segmentations then default to gt -> pred, but warn
+        # Fail if both have segmentations or segmentations missing
         if gt_graph.segmentation is not None and pred_graph.segmentation is not None:
             raise ValueError(
                 "Both datasets have segmentations. "

--- a/src/traccuracy/matchers/_point_seg.py
+++ b/src/traccuracy/matchers/_point_seg.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, cast
+
+from ._base import Matcher
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable
+    from typing import Any
+
+    import numpy as np
+
+    from traccuracy._tracking_graph import TrackingGraph
+
+
+class PointSegMatcher(Matcher):
+    def _compute_mapping(
+        self, gt_graph: TrackingGraph, pred_graph: TrackingGraph
+    ) -> list[tuple[Any, Any]]:
+        # Identify which data has segmentations
+        # s data has seg, p data has points
+        # If both have segmentations then default to gt -> pred, but warn
+        if gt_graph.segmentation is not None and pred_graph.segmentation is not None:
+            seg_source = "pred"
+            s_graph = pred_graph
+            p_graph = gt_graph
+            warnings.warn(
+                "Both GT and Pred have segmentations. Matching GT points to Pred segmentations",
+                stacklevel=1,
+            )
+        elif gt_graph.segmentation is not None:
+            seg_source = "gt"
+            s_graph = gt_graph
+            p_graph = pred_graph
+        elif pred_graph.segmentation is not None:
+            seg_source = "pred"
+            s_graph = pred_graph
+            p_graph = gt_graph
+        else:
+            raise ValueError("Data provided does not contain segmentations.")
+
+        # Cast s_graph.segmentation to ndarray to eliminate none possibility
+        s_graph.segmentation = cast("np.ndarray", s_graph.segmentation)
+
+        mapping: list[tuple[Any, Any]] = []
+        if s_graph.start_frame is None or s_graph.end_frame is None:
+            return mapping
+
+        map_p_nodes, map_s_nodes = [], []
+        for frame in range(s_graph.start_frame, s_graph.end_frame):
+            # Get mapping from p_nodes to s_seg_ids
+            p_nodes = list(p_graph.nodes_by_frame.get(frame, []))
+            p_locations = [p_graph.get_location(node) for node in p_nodes]
+            frame_map = match_point_to_seg(p_nodes, p_locations, s_graph.segmentation[frame])
+
+            # Construct lookup from seg_id to s_node id
+            seg_to_snode = {}
+            for node in s_graph.nodes_by_frame[frame]:
+                seg_id = s_graph.nodes[node][s_graph.label_key]
+                seg_to_snode[seg_id] = node
+
+            # Convert s_seg_ids to s_nodes
+            for p_node, seg_id in frame_map.items():
+                map_p_nodes.append(p_node)
+                map_s_nodes.append(seg_to_snode[seg_id])
+
+        # Construct mapping from tuples of two lists so order gt -> pred is correct
+        if seg_source == "gt":
+            mapping = list(zip(map_s_nodes, map_p_nodes, strict=False))
+        else:
+            mapping = list(zip(map_p_nodes, map_s_nodes, strict=False))
+
+        return mapping
+
+
+def match_point_to_seg(
+    node_ids: list[Hashable], locs: list[list[float]], seg: np.ndarray
+) -> dict[Hashable, int]:
+    """For a single timepoint, identify the segmentation ids which a set of points index into
+
+    Args:
+        node_ids (list[Hashable]): A list of node ids
+        locs (list[list[float]]): A list of locations corresponding to the list of node ids
+        seg (np.ndarray): A 2D segmentation array
+
+    Returns:
+        dict[Hashable, int]: A dictionary mapping from node_id to segmentation value
+    """
+    node_to_segid = {}
+    for node, loc in zip(node_ids, locs, strict=False):
+        # Check if loc is inside of segmentation after casting to int for indexing
+        seg_val = seg[*[int(x) for x in loc]]
+        if seg_val != 0:
+            node_to_segid[node] = seg_val
+
+    return node_to_segid

--- a/src/traccuracy/matchers/_point_seg.py
+++ b/src/traccuracy/matchers/_point_seg.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, cast
 
 from ._base import Matcher
@@ -22,12 +21,9 @@ class PointSegMatcher(Matcher):
         # s data has seg, p data has points
         # If both have segmentations then default to gt -> pred, but warn
         if gt_graph.segmentation is not None and pred_graph.segmentation is not None:
-            seg_source = "pred"
-            s_graph = pred_graph
-            p_graph = gt_graph
-            warnings.warn(
-                "Both GT and Pred have segmentations. Matching GT points to Pred segmentations",
-                stacklevel=1,
+            raise ValueError(
+                "Both datasets have segmentations. "
+                "Please provide only one dataset with segmentations."
             )
         elif gt_graph.segmentation is not None:
             seg_source = "gt"

--- a/src/traccuracy/matchers/_point_seg.py
+++ b/src/traccuracy/matchers/_point_seg.py
@@ -14,6 +14,13 @@ if TYPE_CHECKING:
 
 
 class PointSegMatcher(Matcher):
+    """A matcher that constructs a mapping from a set of points to a segmentation
+    array by determining if a point falls within a segmentation label.
+
+    Either the predicted data or the ground truth can contain a segmentation array,
+    but not both. The matcher will map many points to a single segmentation label.
+    """
+
     def _compute_mapping(
         self, gt_graph: TrackingGraph, pred_graph: TrackingGraph
     ) -> list[tuple[Any, Any]]:

--- a/src/traccuracy/matchers/_point_seg.py
+++ b/src/traccuracy/matchers/_point_seg.py
@@ -93,7 +93,7 @@ def match_point_to_seg(
     node_to_segid = {}
     for node, loc in zip(node_ids, locs, strict=False):
         # Check if loc is inside of segmentation after casting to int for indexing
-        seg_val = seg[*[int(x) for x in loc]]
+        seg_val = seg[tuple([int(x) for x in loc])]
         if seg_val != 0:
             node_to_segid[node] = seg_val
 

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -226,7 +226,7 @@ def test_point_seg_matcher(benchmark, gt_data, pred_data, request):
     gt_data = request.getfixturevalue(gt_data)
     pred_data = request.getfixturevalue(pred_data)
     # Remove segementations from pred data
-    pred_data = TrackingGraph(pred_data.graph)
+    pred_data = TrackingGraph(pred_data.graph, location_keys=gt_data.location_keys)
 
     benchmark.pedantic(
         PointSegMatcher().compute_mapping,

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -5,13 +5,14 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from traccuracy import TrackingGraph
 from traccuracy.loaders import (
     _check_ctc,
     _get_node_attributes,
     _load_tiffs,
     load_ctc_data,
 )
-from traccuracy.matchers import CTCMatcher, IOUMatcher, PointMatcher
+from traccuracy.matchers import CTCMatcher, IOUMatcher, PointMatcher, PointSegMatcher
 from traccuracy.metrics import (
     BasicMetrics,
     CTCMetrics,
@@ -206,6 +207,29 @@ def test_point_matcher(benchmark, gt_data, pred_data, request):
     pred_data = request.getfixturevalue(pred_data)
     benchmark.pedantic(
         PointMatcher(threshold=50).compute_mapping,
+        args=(gt_data, pred_data),
+        rounds=1,
+        iterations=1,
+    )
+
+
+@pytest.mark.timeout(TIMEOUT)
+@pytest.mark.parametrize(
+    "gt_data,pred_data",
+    [
+        ("gt_data_2d", "pred_data_2d"),
+        ("gt_data_3d", "pred_data_3d"),
+    ],
+    ids=["2d", "3d"],
+)
+def test_point_seg_matcher(benchmark, gt_data, pred_data, request):
+    gt_data = request.getfixturevalue(gt_data)
+    pred_data = request.getfixturevalue(pred_data)
+    # Remove segementations from pred data
+    pred_data = TrackingGraph(pred_data.graph)
+
+    benchmark.pedantic(
+        PointSegMatcher().compute_mapping,
         args=(gt_data, pred_data),
         rounds=1,
         iterations=1,

--- a/tests/matchers/test_point_seg.py
+++ b/tests/matchers/test_point_seg.py
@@ -155,8 +155,9 @@ class TestPointSegMatcher:
 
     def test_both_seg(self):
         with pytest.raises(
-            UserWarning,
-            match="Both GT and Pred have segmentations. Matching GT points to Pred segmentations",
+            ValueError,
+            match="Both datasets have segmentations. "
+            "Please provide only one dataset with segmentations.",
         ):
             self.matcher._compute_mapping(self.track_graph, self.track_graph)
 

--- a/tests/matchers/test_point_seg.py
+++ b/tests/matchers/test_point_seg.py
@@ -1,0 +1,185 @@
+import networkx as nx
+import pytest
+
+import tests.examples.segs as ex_segs
+from tests.test_utils import get_movie_with_graph
+from traccuracy import TrackingGraph
+from traccuracy.matchers._point_seg import PointSegMatcher, match_point_to_seg
+
+
+def get_ids_locations(node_dict, loc_keys):
+    ids = list(node_dict.keys())
+    locs = [[node_dict[_id][key] for key in loc_keys] for _id in ids]
+    return ids, locs
+
+
+class TestStandards:
+    """Test match_point_to_seg for all the standard cases
+
+    Tests are written for gt segmentation and predicted points
+    """
+
+    @pytest.mark.parametrize(
+        "data,loc_keys",
+        [
+            (ex_segs.good_segmentation_2d(), ("x", "y")),
+            (ex_segs.good_segmentation_3d(), ("x", "y", "z")),
+        ],
+        ids=["2D", "3D"],
+    )
+    def test_good_seg(self, data, loc_keys):
+        gt_seg = data[0]
+        pred_nodes = ex_segs.nodes_from_segmentation(data[1], pos_keys=loc_keys)
+        pred_ids, pred_locs = get_ids_locations(pred_nodes, loc_keys)
+
+        matches = match_point_to_seg(pred_ids, pred_locs, gt_seg)
+        # dict from pred_id to gt_seg_label
+        assert matches == {2: 1}
+
+    @pytest.mark.parametrize(
+        "data,loc_keys",
+        [
+            (ex_segs.false_positive_segmentation_2d(), ("x", "y")),
+            (ex_segs.false_positive_segmentation_3d(), ("x", "y", "z")),
+        ],
+        ids=["2D", "3D"],
+    )
+    def test_false_pos(self, data, loc_keys):
+        gt_seg = data[0]
+        pred_nodes = ex_segs.nodes_from_segmentation(data[1], pos_keys=loc_keys)
+        pred_ids, pred_locs = get_ids_locations(pred_nodes, loc_keys)
+
+        matches = match_point_to_seg(pred_ids, pred_locs, gt_seg)
+        # dict from pred_id to gt_seg_label
+        # Empty dict if no match
+        assert matches == {}
+
+    @pytest.mark.parametrize(
+        "data,loc_keys",
+        [
+            (ex_segs.false_negative_segmentation_2d(), ("x", "y")),
+            (ex_segs.false_negative_segmentation_3d(), ("x", "y", "z")),
+        ],
+        ids=["2D", "3D"],
+    )
+    def test_false_neg(self, data, loc_keys):
+        gt_seg = data[0]
+        pred_nodes = ex_segs.nodes_from_segmentation(data[1], pos_keys=loc_keys)
+        pred_ids, pred_locs = get_ids_locations(pred_nodes, loc_keys)
+
+        matches = match_point_to_seg(pred_ids, pred_locs, gt_seg)
+        # dict from pred_id to gt_seg_label
+        # empty dict b/c no predicted detection
+        assert matches == {}
+
+    @pytest.mark.parametrize(
+        "data,loc_keys",
+        [
+            (ex_segs.oversegmentation_2d(), ("x", "y")),
+            (ex_segs.oversegmentation_3d(), ("x", "y", "z")),
+        ],
+        ids=["2D", "3D"],
+    )
+    def test_overseg(self, data, loc_keys):
+        gt_seg = data[0]
+        pred_nodes = ex_segs.nodes_from_segmentation(data[1], pos_keys=loc_keys)
+        pred_ids, pred_locs = get_ids_locations(pred_nodes, loc_keys)
+
+        matches = match_point_to_seg(pred_ids, pred_locs, gt_seg)
+        # dict from pred_id to gt_seg_label
+        assert matches == {3: 1, 2: 1}
+
+    @pytest.mark.parametrize(
+        "data,loc_keys",
+        [
+            (ex_segs.undersegmentation_2d(), ("x", "y")),
+            (ex_segs.undersegmentation_3d(), ("x", "y", "z")),
+        ],
+        ids=["2D", "3D"],
+    )
+    def test_underseg(self, data, loc_keys):
+        gt_seg = data[0]
+        pred_nodes = ex_segs.nodes_from_segmentation(data[1], pos_keys=loc_keys)
+        pred_ids, pred_locs = get_ids_locations(pred_nodes, loc_keys)
+
+        matches = match_point_to_seg(pred_ids, pred_locs, gt_seg)
+        # dict from pred_id to gt_seg_label
+        assert matches == {3: 1}
+
+    @pytest.mark.parametrize(
+        "data,loc_keys",
+        [
+            (ex_segs.no_overlap_2d(), ("x", "y")),
+            (ex_segs.no_overlap_3d(), ("x", "y", "z")),
+        ],
+        ids=["2D", "3D"],
+    )
+    def test_no_overlap(self, data, loc_keys):
+        gt_seg = data[0]
+        pred_nodes = ex_segs.nodes_from_segmentation(data[1], pos_keys=loc_keys)
+        pred_ids, pred_locs = get_ids_locations(pred_nodes, loc_keys)
+
+        matches = match_point_to_seg(pred_ids, pred_locs, gt_seg)
+        # dict from pred_id to gt_seg_label
+        assert matches == {}
+
+    @pytest.mark.parametrize(
+        "data,loc_keys",
+        [
+            (ex_segs.multicell_2d(), ("x", "y")),
+            (ex_segs.multicell_3d(), ("x", "y", "z")),
+        ],
+        ids=["2D", "3D"],
+    )
+    def test_no_multicell(self, data, loc_keys):
+        gt_seg = data[0]
+        pred_nodes = ex_segs.nodes_from_segmentation(data[1], pos_keys=loc_keys)
+        pred_ids, pred_locs = get_ids_locations(pred_nodes, loc_keys)
+
+        matches = match_point_to_seg(pred_ids, pred_locs, gt_seg)
+        # dict from pred_id to gt_seg_label
+        assert matches == {3: 1}
+
+
+class TestPointSegMatcher:
+    n_frames = 3
+    n_labels = 3
+    track_graph = get_movie_with_graph(ndims=3, n_frames=n_frames, n_labels=n_labels)
+
+    matcher = PointSegMatcher()
+
+    def test_no_seg(self):
+        data = TrackingGraph(self.track_graph.graph)
+        with pytest.raises(ValueError, match="Data provided does not contain segmentations."):
+            self.matcher._compute_mapping(data, data)
+
+    def test_both_seg(self):
+        with pytest.raises(
+            UserWarning,
+            match="Both GT and Pred have segmentations. Matching GT points to Pred segmentations",
+        ):
+            self.matcher._compute_mapping(self.track_graph, self.track_graph)
+
+    def test_diff_node_ids(self):
+        # Relabel nodes to distinguish point nodes from seg nodes
+        pgraph = nx.relabel_nodes(
+            self.track_graph.graph, {node: f"p_{node}" for node in self.track_graph.graph}
+        )
+        point_data = TrackingGraph(pgraph)
+        # Nodes ids are label_time so not an exact mapping from segmentation label value
+        seg_data = self.track_graph
+
+        matched = self.matcher.compute_mapping(point_data, seg_data)
+        # Check for correct number of pairs
+        assert len(matched.mapping) == self.n_frames * self.n_labels
+        # gt and pred node should be the same after removing p prefix
+        for pair in matched.mapping:
+            assert pair[0][2:] == pair[1]
+
+        # Check matching going in the other direction
+        matched = self.matcher.compute_mapping(seg_data, point_data)
+        # Check for correct number of pairs
+        assert len(matched.mapping) == self.n_frames * self.n_labels
+        # gt and pred node should be the same after removing p prefix
+        for pair in matched.mapping:
+            assert pair[0] == pair[1][2:]

--- a/tests/matchers/test_point_seg.py
+++ b/tests/matchers/test_point_seg.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import numpy as np
 import pytest
 
 import tests.examples.segs as ex_segs
@@ -184,3 +185,10 @@ class TestPointSegMatcher:
         # gt and pred node should be the same after removing p prefix
         for pair in matched.mapping:
             assert pair[0] == pair[1][2:]
+
+    def test_empty(self):
+        point_empty = TrackingGraph(nx.DiGraph())
+        seg_empty = TrackingGraph(nx.DiGraph(), segmentation=np.ndarray(shape=(), dtype="int64"))
+
+        matched = self.matcher.compute_mapping(point_empty, seg_empty)
+        assert len(matched.mapping) == 0


### PR DESCRIPTION
# Proposed Matcher or Metric Addition
- [x] Matcher

This new matcher constructs a mapping between points and segmentations. Either the gt or the pred data can have segmentations, but only one can have segmentations.

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests for the standard test examples documented [here](https://traccuracy.readthedocs.io/en/latest/test_cases/index.html), along with end-to-end tests.
- [x] I have checked that I maintained or improved code coverage.
- [x] I have added benchmarking functions for my change `tests/bench.py`.
- [x] I have added a page to the documentation with a complete description of my matcher/metric including any references.
- [x] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).