### PR TITLE
Limit CLI to CTC only

### DIFF
--- a/src/traccuracy/cli.py
+++ b/src/traccuracy/cli.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Annotated
 
 import typer
 
@@ -30,215 +30,36 @@ def load_all_ctc(
 
 @app.command()
 def run_ctc(
-    gt_dir: str = typer.Argument(..., help="Path to GT tiffs", show_default=False),
-    pred_dir: str = typer.Argument(..., help="Path to prediction/RES tiffs", show_default=False),
-    gt_track_path: str | None = typer.Option(
-        None, help="Path to ctc gt track file", show_default=False
-    ),
-    pred_track_path: str | None = typer.Option(
-        None, help="Path to predicted track file", show_default=False
-    ),
-    loader: str = typer.Option("ctc", help="Loader to bring data into memory"),
-    out_path: str = typer.Option("ctc_log.json", help="Path to save results"),
+    gt_dir: Annotated[str, typer.Argument(help="Path to GT tiffs", show_default=False)],
+    pred_dir: Annotated[
+        str, typer.Argument(help="Path to prediction/RES tiffs", show_default=False)
+    ],
+    gt_track_path: Annotated[
+        str | None, typer.Option(help="Path to ctc gt track file", show_default=False)
+    ] = None,
+    pred_track_path: Annotated[
+        str | None, typer.Option(help="Path to predicted track file", show_default=False)
+    ] = None,
+    out_path: Annotated[str, typer.Option(help="Path to save results")] = "ctc_log.json",
 ) -> None:
     """
-    Run TRA and DET metric on gt and pred data using CTC matching.
+    Load data from CTC format and run TRA and DET metric on gt and pred data using CTC matching.
 
     If --gt_track_path and --pred_track_path are not passed, we find ``*_track.txt``
     files in the data directories. If more than one such file is present, or
     no such files are present, an error is raised.
 
     Results will be dumped to --out_path in JSON format.
-
-    Raises ValueError: if any --loader besides ctc is passed.
     """
     from traccuracy.matchers import CTCMatcher
     from traccuracy.metrics import CTCMetrics
 
-    if loader != "ctc":
-        raise ValueError(
-            f"Only cell tracking challenge (ctc) loader is available, but {loader} was passed."
-        )
     gt_data, pred_data = load_all_ctc(gt_dir, pred_dir, gt_track_path, pred_track_path)
     result, matched = run_metrics(gt_data, pred_data, CTCMatcher(), [CTCMetrics()])
     with open(out_path, "w") as fp:
         json.dump(result, fp)
     logger.info(f"TRA: {result[0]['results']['TRA']}")
     logger.info(f"DET: {result[0]['results']['DET']}")
-
-
-@app.command()
-def run_aogm(
-    gt_dir: str = typer.Argument(..., help="Path to GT tiffs", show_default=False),
-    pred_dir: str = typer.Argument(..., help="Path to prediction/RES tiffs", show_default=False),
-    gt_track_path: str | None = typer.Option(
-        None, help="Path to ctc gt track file", show_default=False
-    ),
-    pred_track_path: str | None = typer.Option(
-        None, help="Path to predicted track file", show_default=False
-    ),
-    loader: str = typer.Option("ctc", help="Loader to bring data into memory"),
-    out_path: str = typer.Option("aogm_log.json", help="Path to save results"),
-    vertex_ns_weight: float = typer.Option(1, help="Weight to assign to nonsplit vertex errors"),
-    vertex_fp_weight: float = typer.Option(
-        1, help="Weight to assign to false positive vertex errors"
-    ),
-    vertex_fn_weight: float = typer.Option(
-        1, help="Weight to assign to false negative vertex errors"
-    ),
-    edge_fp_weight: float = typer.Option(1, help="Weight to assign to false positive edge errors"),
-    edge_fn_weight: float = typer.Option(1, help="Weight to assign to false negative edge errors"),
-    edge_ws_weight: float = typer.Option(
-        1, help="Weight to assign to edges with incorrect semantics"
-    ),
-) -> None:
-    """Run general AOGM measure on gt and pred data using CTC matching.
-
-    If gt_track_path and pred_track_path are not passed, we find ``*_track.txt``
-    files in the data directories. If more than one such file is present, or
-    no such files are present, an error is raised.
-
-    Optionally, weights for each error type can be passed.
-
-    Results will be dumped to out_path in JSON format.
-
-    Raises ValueError: if any --loader besides ctc is passed.
-    """
-    from traccuracy.matchers import CTCMatcher
-    from traccuracy.metrics import AOGMMetrics
-
-    if loader != "ctc":
-        raise ValueError(
-            f"Only cell tracking challenge (ctc) loader is available, but {loader} was passed."
-        )
-    gt_data, pred_data = load_all_ctc(gt_dir, pred_dir, gt_track_path, pred_track_path)
-    result, matched = run_metrics(
-        gt_data,
-        pred_data,
-        CTCMatcher(),
-        [
-            AOGMMetrics(
-                vertex_ns_weight=vertex_ns_weight,
-                vertex_fp_weight=vertex_fp_weight,
-                vertex_fn_weight=vertex_fn_weight,
-                edge_fp_weight=edge_fp_weight,
-                edge_fn_weight=edge_fn_weight,
-                edge_ws_weight=edge_ws_weight,
-            )
-        ],
-    )
-    with open(out_path, "w") as fp:
-        json.dump(result, fp)
-    logger.info(f"AOGM: {result[0]['results']['AOGM']}")
-
-
-@app.command()
-def run_divisions_on_iou(
-    gt_dir: str = typer.Argument(..., help="Path to GT tiffs", show_default=False),
-    pred_dir: str = typer.Argument(..., help="Path to prediction/RES tiffs", show_default=False),
-    gt_track_path: str | None = typer.Option(
-        None, help="Path to ctc gt track file", show_default=False
-    ),
-    pred_track_path: str | None = typer.Option(
-        None, help="Path to predicted track file", show_default=False
-    ),
-    loader: str = typer.Option("ctc", help="Loader to bring data into memory"),
-    out_path: str = typer.Option("div_log_iou.json", help="Path to save results"),
-    match_threshold: float = typer.Option(
-        1,
-        help="Threshold above which the intersection over union of a gt and predicted"
-        " detection match. Default of 1 requires exact matching.",
-    ),
-    frame_buffer: int = typer.Option(
-        0,
-        help="Number of frames to use for division tolerance."
-        " Numbers greater than 0 will produce metrics for 0...n inclusive.",
-    ),
-) -> None:
-    """Run division metrics on gt and pred data using IOU matching.
-
-    If --gt_track_path and --pred_track_path are not passed, we find ``*_track.txt``
-    files in the data directories. If more than one such file is present, or
-    no such files are present, an error is raised.
-
-    Optionally, a --match_threshold and --frame_buffer can be passed.
-
-    Results will be dumped to --out_path in JSON format.
-
-    Raises ValueError: if any --loader besides ctc is passed.
-    """
-    from traccuracy.matchers import IOUMatcher
-    from traccuracy.metrics import DivisionMetrics
-
-    if loader != "ctc":
-        raise ValueError(
-            f"Only cell tracking challenge (ctc) loader is available, but {loader} was passed."
-        )
-    gt_data, pred_data = load_all_ctc(gt_dir, pred_dir, gt_track_path, pred_track_path)
-    result, matched = run_metrics(
-        gt_data,
-        pred_data,
-        IOUMatcher(iou_threshold=match_threshold),
-        [DivisionMetrics(max_frame_buffer=frame_buffer)],
-    )
-    with open(out_path, "w") as fp:
-        json.dump(result, fp)
-    res_str = ""
-    for frame_buffer, res_dict in result[0]["results"].items():
-        res_str += f"{frame_buffer} F1: {res_dict['Division F1']}\n"
-    logger.info(res_str)
-
-
-@app.command()
-def run_divisions_on_ctc(
-    gt_dir: str = typer.Argument(..., help="Path to GT tiffs", show_default=False),
-    pred_dir: str = typer.Argument(..., help="Path to prediction/RES tiffs", show_default=False),
-    gt_track_path: str | None = typer.Option(
-        None, help="Path to ctc gt track file", show_default=False
-    ),
-    pred_track_path: str | None = typer.Option(
-        None, help="Path to predicted track file", show_default=False
-    ),
-    loader: str = typer.Option("ctc", help="Loader to bring data into memory"),
-    out_path: str = typer.Option("div_log_ctc.json", help="Path to save results"),
-    frame_buffer: int = typer.Option(
-        0,
-        help="Number of frames to use for division tolerance."
-        " Numbers greater than 0 will produce metrics for 0...n inclusive.",
-    ),
-) -> None:
-    """Run division metrics on gt and pred data using CTC matching.
-
-    If --gt_track_path and --pred_track_path are not passed, we find ``*_track.txt``
-    files in the data directories. If more than one such file is present, or
-    no such files are present, an error is raised.
-
-    Optionally, a --frame_buffer can be passed.
-
-    Results will be dumped to --out_path in JSON format.
-
-    Raises ValueError: if any --loader besides ctc is passed.
-    """
-    from traccuracy.matchers import CTCMatcher
-    from traccuracy.metrics import DivisionMetrics
-
-    if loader != "ctc":
-        raise ValueError(
-            f"Only cell tracking challenge (ctc) loader is available, but {loader} was passed."
-        )
-    gt_data, pred_data = load_all_ctc(gt_dir, pred_dir, gt_track_path, pred_track_path)
-    result, matched = run_metrics(
-        gt_data,
-        pred_data,
-        CTCMatcher(),
-        [DivisionMetrics(max_frame_buffer=frame_buffer)],
-    )
-    with open(out_path, "w") as fp:
-        json.dump(result, fp)
-    res_str = ""
-    for frame_buffer, res_dict in result[0]["results"].items():
-        res_str += f"{frame_buffer} F1: {res_dict['Division F1']}\n"
-    logger.info(res_str)
 
 
 typer_click_object = typer.main.get_command(app)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,50 @@
+import os
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from traccuracy.cli import app
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+runner = CliRunner()
+
+
+def test_run_ctc():
+    data_path = os.path.join(ROOT_DIR, "examples/sample-data/Fluo-N2DL-HeLa/01_RES")
+    track_path = os.path.join(data_path, "res_track.txt")
+    log_path = "ctc_log.json"
+
+    # Test without specifying track path
+    result = runner.invoke(app, [data_path, data_path])
+    assert result.exit_code == 0, result.stdout
+    assert os.path.exists(log_path)
+    os.remove(log_path)
+
+    # Specify track paths
+    result = runner.invoke(
+        app, [data_path, data_path, "--gt-track-path", track_path, "--pred-track-path", track_path]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert os.path.exists(log_path)
+    os.remove(log_path)
+
+    # Change output name
+    log_path = "other_output.json"
+    result = runner.invoke(
+        app,
+        [
+            data_path,
+            data_path,
+            "--gt-track-path",
+            track_path,
+            "--pred-track-path",
+            track_path,
+            "--out-path",
+            log_path,
+        ],
+    )
+    assert result.exit_code == 0, result.stderr
+    assert os.path.exists(log_path)
+    os.remove(log_path)


### PR DESCRIPTION
# Proposed Change
Closes #79 to just use the CLI to run standard CTC metrics on CTC formatted data
Also adds in tests that actually runs the CLI with different arguments

# Types of Changes
What types of changes does your code introduce? Delete those that do not apply.
- Maintenance (e.g. dependencies, CI, releases, etc.)

Which topics does your change affect? Delete those that do not apply.
- Core functionality (e.g. `TrackingGraph`, `run_metrics`, `cli`, etc.)

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [x] I have read the developer/contributing docs.
- [x] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [x] I have checked that I maintained or improved code coverage.
- [x] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [x] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [x] I have updated the general documentation including Metric descriptions and example notebooks if necessary.

# Further Comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...