### PR TITLE
Remove graph copying in division metrics with frame buffer

### DIFF
--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -86,19 +86,12 @@ class DivisionMetrics(Metric):
         Returns:
             dict: Returns a nested dictionary with one dictionary per frame buffer value
         """
-        data = _evaluate_division_events(
+        _evaluate_division_events(
             data,
             max_frame_buffer=self.frame_buffer,
         )
 
         return self._calculate_metrics(data.gt_graph, data.pred_graph)
-        # return {
-        #     f"Frame Buffer {fb}": self._calculate_metrics(
-        #         matched_data.gt_graph,
-        #         matched_data.pred_graph,
-        #     )
-        #     for fb, matched_data in div_annotations.items()
-        # }
 
     def _get_mbc(self, gt_div_count: int, tp_division_count: int, fp_division_count: int) -> float:
         """Computes Mitotic Branching Correctness and returns nan if there are no gt
@@ -116,7 +109,9 @@ class DivisionMetrics(Metric):
             return np.nan
         return tp_division_count / (fp_division_count + gt_div_count)
 
-    def _calculate_metrics(self, g_gt: TrackingGraph, g_pred: TrackingGraph) -> dict[str, float]:
+    def _calculate_metrics(
+        self, g_gt: TrackingGraph, g_pred: TrackingGraph
+    ) -> dict[str, dict[str, float]]:
         gt_div_count = len(g_gt.get_divisions())
         pred_div_count = len(g_pred.get_divisions())
         tp_division_count = len(g_gt.get_nodes_with_flag(NodeFlag.TP_DIV))

--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -144,10 +144,7 @@ class DivisionMetrics(Metric):
             new_tp_div_count = 0
             for node in g_pred.graph.nodes:
                 node_info = g_pred.graph.nodes[node]
-                if (
-                    node_info.get("min_buffer_correct", np.nan) is not np.nan
-                    and node_info["min_buffer_correct"] <= fb
-                ):
+                if node_info.get("min_buffer_correct", np.nan) <= fb:
                     new_tp_div_count += 1
             new_fp_div_count = fp_division_count - new_tp_div_count
             new_fn_div_count = fn_division_count - new_tp_div_count

--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -92,13 +92,13 @@ class DivisionMetrics(Metric):
         )
 
         return self._calculate_metrics(data.gt_graph, data.pred_graph)
-        return {
-            f"Frame Buffer {fb}": self._calculate_metrics(
-                matched_data.gt_graph,
-                matched_data.pred_graph,
-            )
-            for fb, matched_data in div_annotations.items()
-        }
+        # return {
+        #     f"Frame Buffer {fb}": self._calculate_metrics(
+        #         matched_data.gt_graph,
+        #         matched_data.pred_graph,
+        #     )
+        #     for fb, matched_data in div_annotations.items()
+        # }
 
     def _get_mbc(self, gt_div_count: int, tp_division_count: int, fp_division_count: int) -> float:
         """Computes Mitotic Branching Correctness and returns nan if there are no gt

--- a/src/traccuracy/utils.py
+++ b/src/traccuracy/utils.py
@@ -1,0 +1,37 @@
+import copy
+
+import numpy as np
+
+from traccuracy import NodeFlag, TrackingGraph
+from traccuracy.matchers import Matched
+
+
+def get_corrected_division_graphs_with_delta(
+    matched: Matched, frame_buffer: int = 0
+) -> tuple[TrackingGraph, TrackingGraph]:
+    """Returns copies of graphs with divisions corrected.
+
+    All divisions corrected by a frame_buffer value less than or equal
+    to the given frame buffer are marked as `TP_DIV`.
+
+    Args:
+        matched (Matched): Matched object for set of GT and Pred data.
+            Must be annotated with division events.
+        frame_buffer (int): Maximum frame buffer to use for division correction
+
+    Returns:
+        tuple[TrackingGraph, TrackingGraph]: Tuple of corrected GT and Pred division graphs
+    """
+    corrected_gt_graph = copy.deepcopy(matched.gt_graph)
+    corrected_pred_graph = copy.deepcopy(matched.pred_graph)
+
+    for node in corrected_gt_graph.get_nodes_with_flag(NodeFlag.FN_DIV):
+        if corrected_gt_graph.graph.nodes[node].get("min_buffer_correct", np.nan) <= frame_buffer:
+            corrected_gt_graph.graph.nodes[node].pop(NodeFlag.FN_DIV)
+            corrected_gt_graph.graph.nodes[node][NodeFlag.TP_DIV] = True
+    for node in corrected_pred_graph.get_nodes_with_flag(NodeFlag.FP_DIV):
+        if corrected_pred_graph.graph.nodes[node].get("min_buffer_correct", np.nan) <= frame_buffer:
+            corrected_pred_graph.graph.nodes[node].pop(NodeFlag.FP_DIV)
+            corrected_pred_graph.graph.nodes[node][NodeFlag.TP_DIV] = True
+
+    return corrected_gt_graph, corrected_pred_graph

--- a/src/traccuracy/utils.py
+++ b/src/traccuracy/utils.py
@@ -20,7 +20,7 @@ def get_corrected_division_graphs_with_delta(
         frame_buffer (int): Maximum frame buffer to use for division correction
 
     Returns:
-        tuple[TrackingGraph, TrackingGraph]: Tuple of corrected GT and Pred division graphs
+        tuple[TrackingGraph, TrackingGraph]: Tuple of corrected GT and Pred graphs
     """
     corrected_gt_graph = copy.deepcopy(matched.gt_graph)
     corrected_pred_graph = copy.deepcopy(matched.pred_graph)

--- a/tests/track_errors/test_divisions.py
+++ b/tests/track_errors/test_divisions.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 import tests.examples.graphs as ex_graphs
@@ -127,15 +126,15 @@ class TestStandardShifted:
     )
     def test_div_1early(self, n_frames, matched, gt_node, pred_node):
         _classify_divisions(matched)
-        shifted = _correct_shifted_divisions(matched, n_frames=n_frames)
+        _correct_shifted_divisions(matched, n_frames=n_frames)
 
-        attrs = shifted.gt_graph.nodes[gt_node]
-        assert attrs.get(NodeFlag.TP_DIV) is True
-        assert NodeFlag.FN_DIV not in attrs
+        attrs = matched.gt_graph.nodes[gt_node]
+        assert NodeFlag.FN_DIV in attrs
+        assert attrs.get("min_buffer_correct") == 1
 
-        attrs = shifted.pred_graph.nodes[pred_node]
-        assert attrs.get(NodeFlag.TP_DIV) is True
-        assert NodeFlag.FP_DIV not in attrs
+        attrs = matched.pred_graph.nodes[pred_node]
+        assert NodeFlag.FP_DIV in attrs
+        assert attrs.get("min_buffer_correct") == 1
 
     @pytest.mark.parametrize("n_frames", [1, 3])
     @pytest.mark.parametrize(
@@ -145,22 +144,19 @@ class TestStandardShifted:
     )
     def test_div_2early(self, n_frames, matched, gt_node, pred_node):
         _classify_divisions(matched)
-        shifted = _correct_shifted_divisions(matched, n_frames=n_frames)
+        _correct_shifted_divisions(matched, n_frames=n_frames)
 
-        if n_frames == 1:  # Not corrected
-            attrs = shifted.gt_graph.nodes[gt_node]
-            assert attrs.get(NodeFlag.FN_DIV) is True
+        attrs = matched.gt_graph.nodes[gt_node]
+        assert attrs.get(NodeFlag.FN_DIV) is True
 
-            attrs = shifted.pred_graph.nodes[pred_node]
-            assert attrs.get(NodeFlag.FP_DIV) is True
-        elif n_frames == 3:  # corrected
-            attrs = shifted.gt_graph.nodes[gt_node]
-            assert attrs.get(NodeFlag.TP_DIV) is True
-            assert NodeFlag.FN_DIV not in attrs
+        attrs = matched.pred_graph.nodes[pred_node]
+        assert attrs.get(NodeFlag.FP_DIV) is True
+        if n_frames == 3:  # corrected
+            attrs = matched.gt_graph.nodes[gt_node]
+            assert attrs.get("min_buffer_correct") == 3
 
-            attrs = shifted.pred_graph.nodes[pred_node]
-            assert attrs.get(NodeFlag.TP_DIV) is True
-            assert NodeFlag.FP_DIV not in attrs
+            attrs = matched.pred_graph.nodes[pred_node]
+            assert attrs.get("min_buffer_correct") == 3
 
     @pytest.mark.parametrize("n_frames", [1, 2])
     @pytest.mark.parametrize(
@@ -170,15 +166,15 @@ class TestStandardShifted:
     )
     def test_div_1late(self, n_frames, matched, gt_node, pred_node):
         _classify_divisions(matched)
-        shifted = _correct_shifted_divisions(matched, n_frames=n_frames)
+        _correct_shifted_divisions(matched, n_frames=n_frames)
 
-        attrs = shifted.gt_graph.nodes[gt_node]
-        assert attrs.get(NodeFlag.TP_DIV) is True
-        assert NodeFlag.FN_DIV not in attrs
+        attrs = matched.gt_graph.nodes[gt_node]
+        assert attrs.get(NodeFlag.FN_DIV) is True
+        assert attrs.get("min_buffer_correct") == 1
 
-        attrs = shifted.pred_graph.nodes[pred_node]
-        assert attrs.get(NodeFlag.TP_DIV) is True
-        assert NodeFlag.FP_DIV not in attrs
+        attrs = matched.pred_graph.nodes[pred_node]
+        assert attrs.get(NodeFlag.FP_DIV) is True
+        assert attrs.get("min_buffer_correct") == 1
 
     @pytest.mark.parametrize("n_frames", [1, 3])
     @pytest.mark.parametrize(
@@ -188,35 +184,36 @@ class TestStandardShifted:
     )
     def test_div_2late(self, n_frames, matched, gt_node, pred_node):
         _classify_divisions(matched)
-        shifted = _correct_shifted_divisions(matched, n_frames=n_frames)
+        _correct_shifted_divisions(matched, n_frames=n_frames)
 
         if n_frames == 1:  # Not corrected
-            attrs = shifted.gt_graph.nodes[gt_node]
+            attrs = matched.gt_graph.nodes[gt_node]
             assert attrs.get(NodeFlag.FN_DIV) is True
 
-            attrs = shifted.pred_graph.nodes[pred_node]
+            attrs = matched.pred_graph.nodes[pred_node]
             assert attrs.get(NodeFlag.FP_DIV) is True
-        elif n_frames == 3:  # corrected
-            attrs = shifted.gt_graph.nodes[gt_node]
-            assert attrs.get(NodeFlag.TP_DIV) is True
-            assert NodeFlag.FN_DIV not in attrs
 
-            attrs = shifted.pred_graph.nodes[pred_node]
-            assert attrs.get(NodeFlag.TP_DIV) is True
-            assert NodeFlag.FP_DIV not in attrs
+        elif n_frames == 3:  # corrected
+            attrs = matched.gt_graph.nodes[gt_node]
+            assert NodeFlag.FN_DIV in attrs
+            assert attrs.get("min_buffer_correct") == 3
+
+            attrs = matched.pred_graph.nodes[pred_node]
+            assert NodeFlag.FP_DIV in attrs
+            assert attrs.get("min_buffer_correct") == 3
 
     def test_minimal_matching(self):
         matched = ex_graphs.div_shift_min_match()
         _classify_divisions(matched)
-        shifted = _correct_shifted_divisions(matched, n_frames=1)
+        _correct_shifted_divisions(matched, n_frames=1)
 
-        attrs = shifted.gt_graph.nodes[2]
-        assert attrs.get(NodeFlag.TP_DIV) is True
-        assert NodeFlag.FN_DIV not in attrs
+        attrs = matched.gt_graph.nodes[2]
+        assert NodeFlag.FN_DIV in attrs
+        assert attrs.get("min_buffer_correct") == 1
 
-        attrs = shifted.pred_graph.nodes[11]
-        assert attrs.get(NodeFlag.TP_DIV) is True
-        assert NodeFlag.FP_DIV not in attrs
+        attrs = matched.pred_graph.nodes[11]
+        assert NodeFlag.FP_DIV in attrs
+        assert attrs.get("min_buffer_correct") == 1
 
     @pytest.mark.parametrize(
         "matched",
@@ -228,14 +225,14 @@ class TestStandardShifted:
     )
     def test_bad_matching(self, matched):
         _classify_divisions(matched)
-        shifted = _correct_shifted_divisions(matched, n_frames=1)
+        _correct_shifted_divisions(matched, n_frames=1)
 
         # No correction of shifted divisions b/c matching criteria not met
-        attrs = shifted.gt_graph.nodes[2]
+        attrs = matched.gt_graph.nodes[2]
         assert attrs.get(NodeFlag.TP_DIV) is None
         assert attrs.get(NodeFlag.FN_DIV) is True
 
-        attrs = shifted.pred_graph.nodes[11]
+        attrs = matched.pred_graph.nodes[11]
         assert attrs.get(NodeFlag.TP_DIV) is None
         assert attrs.get(NodeFlag.FP_DIV) is True
 
@@ -259,24 +256,24 @@ class TestGapCloseDivisions:
     def test_gap_close_shift(self):
         matched = ex_graphs.div_parent_gap()
         _classify_divisions(matched)
-        shifted = _correct_shifted_divisions(matched, n_frames=1)
+        _correct_shifted_divisions(matched, n_frames=1)
         # division is not corrected because `get_succ_by_t` traverses
         # two successors given a delta of 1, but our immediate successors
         # are two frames apart. We therefore end up checking children 13 and 14
         # against gt children 4 and 5.
-        assert NodeFlag.FP_DIV in shifted.pred_graph.nodes[9]
-        assert NodeFlag.FN_DIV in shifted.gt_graph.nodes[3]
+        assert NodeFlag.FP_DIV in matched.pred_graph.nodes[9]
+        assert NodeFlag.FN_DIV in matched.gt_graph.nodes[3]
 
         #
         matched = ex_graphs.div_daughter_gap()
         _classify_divisions(matched)
-        shifted = _correct_shifted_divisions(matched, n_frames=1)
+        _correct_shifted_divisions(matched, n_frames=1)
         # `_correct_shifted_divisions` only checks pairs of TP/FP
         # divisions, so the WC_DIV is not corrected. To correct it,
         # we would need to check shifted successors of all WC_DIV
         # matched nodes
-        assert NodeFlag.WC_DIV in shifted.pred_graph.nodes[10]
-        assert NodeFlag.WC_DIV in shifted.gt_graph.nodes[3]
+        assert NodeFlag.WC_DIV in matched.pred_graph.nodes[10]
+        assert NodeFlag.WC_DIV in matched.gt_graph.nodes[3]
 
 
 def test_evaluate_division_events():
@@ -288,6 +285,9 @@ def test_evaluate_division_events():
         TrackingGraph(g_gt), TrackingGraph(g_pred), mapper, {"name": "DummyMatcher"}
     )
 
-    results = _evaluate_division_events(matched_data, max_frame_buffer=frame_buffer)
+    matched = _evaluate_division_events(matched_data, max_frame_buffer=frame_buffer)
 
-    assert np.all([isinstance(k, int) for k in results.keys()])
+    for node in matched.gt_graph.get_nodes_with_flag(NodeFlag.FN_DIV):
+        assert "min_buffer_correct" in matched.gt_graph.nodes[node]
+    for node in matched.pred_graph.get_nodes_with_flag(NodeFlag.FP_DIV):
+        assert "min_buffer_correct" in matched.pred_graph.nodes[node]

--- a/tests/track_errors/test_divisions.py
+++ b/tests/track_errors/test_divisions.py
@@ -11,6 +11,19 @@ from traccuracy.track_errors.divisions import (
     _get_pred_by_t,
     _get_succ_by_t,
 )
+from traccuracy.utils import get_corrected_division_graphs_with_delta
+
+
+def assert_corrected_graphs(matched, gt_node, pred_node, n_frames):
+    corrected_gt, corrected_pred = get_corrected_division_graphs_with_delta(matched, n_frames)
+
+    attrs = corrected_gt.nodes[gt_node]
+    assert NodeFlag.FN_DIV not in attrs
+    assert NodeFlag.TP_DIV in attrs
+
+    attrs = corrected_pred.nodes[pred_node]
+    assert NodeFlag.FP_DIV not in attrs
+    assert NodeFlag.TP_DIV in attrs
 
 
 class TestStandardsDivisions:
@@ -136,6 +149,8 @@ class TestStandardShifted:
         assert NodeFlag.FP_DIV in attrs
         assert attrs.get("min_buffer_correct") == 1
 
+        assert_corrected_graphs(matched, gt_node, pred_node, n_frames)
+
     @pytest.mark.parametrize("n_frames", [1, 3])
     @pytest.mark.parametrize(
         "matched, gt_node, pred_node",
@@ -158,6 +173,8 @@ class TestStandardShifted:
             attrs = matched.pred_graph.nodes[pred_node]
             assert attrs.get("min_buffer_correct") == 3
 
+            assert_corrected_graphs(matched, gt_node, pred_node, n_frames)
+
     @pytest.mark.parametrize("n_frames", [1, 2])
     @pytest.mark.parametrize(
         "matched, gt_node, pred_node",
@@ -175,6 +192,8 @@ class TestStandardShifted:
         attrs = matched.pred_graph.nodes[pred_node]
         assert attrs.get(NodeFlag.FP_DIV) is True
         assert attrs.get("min_buffer_correct") == 1
+
+        assert_corrected_graphs(matched, gt_node, pred_node, n_frames)
 
     @pytest.mark.parametrize("n_frames", [1, 3])
     @pytest.mark.parametrize(
@@ -202,6 +221,8 @@ class TestStandardShifted:
             assert NodeFlag.FP_DIV in attrs
             assert attrs.get("min_buffer_correct") == 3
 
+            assert_corrected_graphs(matched, gt_node, pred_node, n_frames)
+
     def test_minimal_matching(self):
         matched = ex_graphs.div_shift_min_match()
         _classify_divisions(matched)
@@ -214,6 +235,8 @@ class TestStandardShifted:
         attrs = matched.pred_graph.nodes[11]
         assert NodeFlag.FP_DIV in attrs
         assert attrs.get("min_buffer_correct") == 1
+
+        assert_corrected_graphs(matched, 2, 11, 1)
 
     @pytest.mark.parametrize(
         "matched",


### PR DESCRIPTION
If you are implementing a new matcher or metric, please append this `&template=new_matcher_metric.md` to your url to load the correct template.

# Proposed Change

This PR removes the need to generate graph copies for each frame buffer value being tested in calculating division metrics.

Annotated graphs will now retain their `FP_DIV`/`FN_DIV` annotations for divisions incorrect at `frame_buffer=0` and gain an additional attribute `min_buffer_correct` that stores `np.nan` when a buffer value that corrects the division hasn't been tried, otherwise the minimal frame buffer that would correct the division.

Note that in this implementation, **divisions will remain correct for buffer values greater than the minimal buffer value that corrects the division**.

This PR also adds a utility function that returns copies of the annotated graphs with all divisions corrected by the given frame buffer value marked as `TP_DIV`.

# Types of Changes
- New feature or enhancement
- Documentation update

Which topics does your change affect? Delete those that do not apply.
- Metrics

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the developer/contributing docs.
- [ ] I have added tests that prove that my feature works in various situations or tests the bugfix (if appropriate).
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have checked the benchmarking action to verify that my changes did not adversely affect performance.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).
- [ ] I have updated the general documentation including Metric descriptions and example notebooks if necessary.