### PR TITLE
Document branching correctness = division F1 score

### DIFF
--- a/src/traccuracy/metrics/_divisions.py
+++ b/src/traccuracy/metrics/_divisions.py
@@ -58,7 +58,7 @@ class DivisionMetrics(Metric):
 
     - Division Recall
     - Division Precision
-    - Division F1 Score
+    - Division F1 Score (also Branching Correctness)
     - Mitotic Branching Correctness: TP / (TP + FP + FN) as defined by Ulicna, K.,
         Vallardi, G., Charras, G. & Lowe, A. R. Automated deep lineage tree analysis
         using a Bayesian single cell tracking approach. Frontiers in Computer Science


### PR DESCRIPTION
# Proposed Matcher or Metric Addition
- Metric

Closes #38 by documenting that BC is equivalent to the Division F1 score. I expanded the CTC metrics documentation with code samples showing how to directly calculate and retrieve each metric. I also added a new section for the CTC bio metrics describing branching correctness.

# Checklist
Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

- [ ] I have read the developer/contributing docs.
- [ ] I have added tests for the standard test examples documented [here](https://traccuracy.readthedocs.io/en/latest/test_cases/index.html), along with end-to-end tests.
- [ ] I have checked that I maintained or improved code coverage.
- [ ] I have added benchmarking functions for my change `tests/bench.py`.
- [ ] I have added a page to the documentation with a complete description of my matcher/metric including any references.
- [ ] I have written docstrings and checked that they render correctly in the Read The Docs build (created after the PR is opened).

# Further Comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...